### PR TITLE
Adjust initial monster count and starting inventory

### DIFF
--- a/index.html
+++ b/index.html
@@ -920,13 +920,19 @@
             gameState.player.y = 1;
             gameState.dungeon[1][1] = 'empty';
 
+            if (gameState.floor === 1 && gameState.player.inventory.length === 0) {
+                const starterPotion = createItem('healthPotion', 0, 0);
+                gameState.player.inventory.push(starterPotion);
+            }
+
             const exitX = size - 2;
             const exitY = size - 2;
             gameState.exitLocation = { x: exitX, y: exitY };
             gameState.dungeon[exitY][exitX] = 'exit';
 
             const monsterTypes = Object.keys(MONSTER_TYPES);
-            for (let i = 0; i < 5; i++) {
+            const monsterCount = gameState.floor === 1 ? 3 : 5;
+            for (let i = 0; i < monsterCount; i++) {
                 let x, y;
                 do {
                     x = Math.floor(Math.random() * size);


### PR DESCRIPTION
## Summary
- reduce monster count on the first floor
- add a starter health potion to the player's inventory at game start

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407dd26a2083279d815d93a119f21d