### PR TITLE
Add wizard mercenary type

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,6 +454,7 @@
                 <h2>💼 용병 고용</h2>
                 <button class="hire-button" onclick="hireMercenary('WARRIOR')">⚔️ 전사 고용 (50💰)</button>
                 <button class="hire-button" onclick="hireMercenary('ARCHER')">🏹 궁수 고용 (60💰)</button>
+                <button class="hire-button" onclick="hireMercenary('WIZARD')">🧙‍♂️ 마법사 고용 (80💰)</button>
                 <button class="hire-button" onclick="hireMercenary('HEALER')">✚ 힐러 고용 (70💰)</button>
             </div>
             
@@ -489,7 +490,8 @@
                 baseDefense: 2,
                 role: 'tank',
                 description: '높은 체력과 방어력을 가진 근접 전투 용병',
-                cost: 50
+                cost: 50,
+                range: 1
             },
             ARCHER: {
                 name: '🏹 궁수',
@@ -499,7 +501,19 @@
                 baseDefense: 1,
                 role: 'ranged',
                 description: '원거리에서 적을 공격하는 용병',
-                cost: 60
+                cost: 60,
+                range: 3
+            },
+            WIZARD: {
+                name: '🧙‍♂️ 마법사',
+                icon: '🔮',
+                baseHealth: 9,
+                baseAttack: 6,
+                baseDefense: 1,
+                role: 'caster',
+                description: '강력한 마법으로 적을 공격하는 용병',
+                cost: 80,
+                range: 2
             },
             HEALER: {
                 name: '✚ 힐러',
@@ -509,7 +523,8 @@
                 baseDefense: 1,
                 role: 'support',
                 description: '아군을 치료하는 지원 용병',
-                cost: 70
+                cost: 70,
+                range: 1
             }
         };
 
@@ -1247,6 +1262,7 @@
                 name: mercType.name,
                 icon: mercType.icon,
                 role: mercType.role,
+                range: mercType.range !== undefined ? mercType.range : (mercType.role === 'ranged' ? 3 : mercType.role === 'caster' ? 2 : 1),
                 x: x,
                 y: y,
                 level: 1,
@@ -1880,7 +1896,7 @@
             });
             
             if (nearestMonster) {
-                const attackRange = mercenary.role === 'ranged' ? 3 : 1;
+                const attackRange = mercenary.range !== undefined ? mercenary.range : (mercenary.role === 'ranged' ? 3 : mercenary.role === 'caster' ? 2 : 1);
                 if (nearestDistance <= attackRange) {
                     // 공격 (장비 보너스 적용)
                     let totalAttack = mercenary.attack;


### PR DESCRIPTION
## Summary
- add WIZARD to MERCENARY_TYPES
- support range on mercenaries and caster role
- update mercenary creation and attack logic
- expose hiring button for WIZARD

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68409051984c83278376f0315e17b031