### PR TITLE
Add trait info footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,6 +406,36 @@
         .message-log::-webkit-scrollbar-thumb:hover {
             background: #777;
         }
+
+        /* Trait info panel */
+        .trait-info {
+            background: linear-gradient(135deg, #2a2a2a, #333);
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
+            border: 1px solid #555;
+            max-width: 1400px;
+            width: 100%;
+            margin-top: 15px;
+            font-size: 13px;
+        }
+        .trait-info h2 {
+            color: #ff6600;
+            margin: 0 0 12px 0;
+            border-bottom: 2px solid #ff6600;
+            padding-bottom: 8px;
+            text-align: center;
+            font-size: 16px;
+        }
+        .trait-info ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .trait-info li {
+            margin-bottom: 4px;
+            font-size: 12px;
+        }
     </style>
 </head>
 <body>
@@ -469,6 +499,8 @@
             </div>
         </div>
     </div>
+
+    <div id="trait-info" class="trait-info"></div>
 
     <script>
         // 아이템 타입 정의
@@ -554,6 +586,20 @@
             '신속(체력↓)': '이동 속도 증가, 체력 감소.',
             '치유 전문(공격↓)': '치유 능력 향상, 공격력 감소.'
         };
+
+        // 특성 정보 영역 렌더링
+        function renderTraitInfo() {
+            const container = document.getElementById('trait-info');
+            if (!container) return;
+            container.innerHTML = '<h2>📜 특성 정보</h2>';
+            const ul = document.createElement('ul');
+            for (const [name, desc] of Object.entries(TRAIT_DETAILS)) {
+                const li = document.createElement('li');
+                li.innerHTML = `<strong>${name}</strong>: ${desc}`;
+                ul.appendChild(li);
+            }
+            container.appendChild(ul);
+        }
 
         // 몬스터 타입 정의
         const MONSTER_TYPES = {
@@ -2016,6 +2062,7 @@
 
         // 초기화 및 입력 처리
         generateDungeon();
+        renderTraitInfo();
         document.getElementById('up').onclick = () => movePlayer(0, -1);
         document.getElementById('down').onclick = () => movePlayer(0, 1);
         document.getElementById('left').onclick = () => movePlayer(-1, 0);


### PR DESCRIPTION
## Summary
- add trait info panel at the bottom of the page
- list trait names and descriptions from `TRAIT_DETAILS`
- style the panel to fit existing UI

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68409053789083278b16c6f3789e9b3c