### PR TITLE
Fix mercenary follow range

### DIFF
--- a/index.html
+++ b/index.html
@@ -2437,7 +2437,7 @@ function healTarget(healer, target) {
                                         gameState.dungeon[backStep.y][backStep.x] !== 'wall' &&
                                         gameState.dungeon[backStep.y][backStep.x] !== 'monster' &&
                                         !(backStep.x === gameState.player.x && backStep.y === gameState.player.y) &&
-                                        backDist >= minDistanceFromPlayer && backDist <= maxDistanceFromPlayer;
+                                        backDist >= minDistanceFromPlayer && backDist < playerDistance;
                                     if (backValid) {
                                         if (backOccupying) {
                                             const bOldX = mercenary.x;
@@ -2465,7 +2465,7 @@ function healTarget(healer, target) {
                                     gameState.dungeon[backStep.y][backStep.x] !== 'wall' &&
                                     gameState.dungeon[backStep.y][backStep.x] !== 'monster' &&
                                     !(backStep.x === gameState.player.x && backStep.y === gameState.player.y) &&
-                                    backDist >= minDistanceFromPlayer && backDist <= maxDistanceFromPlayer;
+                                    backDist >= minDistanceFromPlayer && backDist < playerDistance;
                                 if (backValid) {
                                     if (backOccupying) {
                                         const bOldX = mercenary.x;
@@ -2496,7 +2496,7 @@ function healTarget(healer, target) {
                             gameState.dungeon[step.y][step.x] !== 'wall' &&
                             gameState.dungeon[step.y][step.x] !== 'monster' &&
                             !(step.x === gameState.player.x && step.y === gameState.player.y) &&
-                            distAfter >= minDistanceFromPlayer && distAfter <= maxDistanceFromPlayer;
+                            distAfter >= minDistanceFromPlayer && distAfter < playerDistance;
 
                         if (stepValid) {
                             if (occupyingMerc) {


### PR DESCRIPTION
## Summary
- allow mercenaries to move toward the player even if still outside the max follow range
- relax backtracking distance checks to let mercenaries gradually close the gap
- update follow-distance logic when no monsters are present

## Testing
- `node tests/mercenaryFollow.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68410daca7e88327971c3b3a1d18030b