### PR TITLE
Fix mercenary capacity check and add replacement test

### DIFF
--- a/index.html
+++ b/index.html
@@ -1547,21 +1547,21 @@ function healTarget(healer, target) {
                 return;
             }
 
-            const aliveMercs = gameState.mercenaries.filter(m => m.alive);
-            if (aliveMercs.length >= 3) {
-                const options = aliveMercs.map((m, i) => `${i + 1}: ${m.name}`).join('\n');
+            if (gameState.mercenaries.length >= 3) {
+                const allMercs = gameState.mercenaries;
+                const options = allMercs.map((m, i) => `${i + 1}: ${m.name}${m.alive ? '' : ' (dead)'}`).join('\n');
                 const choice = prompt(`👥 최대 3명의 용병을 보유 중입니다. 교체할 용병을 선택하세요:\n${options}`);
                 if (choice === null) {
                     addMessage('❌ 고용이 취소되었습니다.', 'info');
                     return;
                 }
                 const index = parseInt(choice, 10);
-                if (isNaN(index) || index < 1 || index > aliveMercs.length) {
+                if (isNaN(index) || index < 1 || index > allMercs.length) {
                     addMessage('❌ 고용이 취소되었습니다.', 'info');
                     return;
                 }
-                const toRemove = aliveMercs[index - 1];
-                const rmIndex = gameState.mercenaries.findIndex(m => m.id === toRemove.id);
+                const toRemove = allMercs[index - 1];
+                const rmIndex = gameState.mercenaries.indexOf(toRemove);
                 if (rmIndex !== -1) {
                     gameState.mercenaries.splice(rmIndex, 1);
                 }

--- a/tests/hireMercenaryReplacement.test.js
+++ b/tests/hireMercenaryReplacement.test.js
@@ -1,0 +1,52 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+
+  const { hireMercenary, gameState } = dom.window;
+
+  gameState.player.gold = 999;
+
+  let promptCount = 0;
+  dom.window.prompt = () => {
+    promptCount++;
+    return '1';
+  };
+
+  hireMercenary('WARRIOR');
+  hireMercenary('ARCHER');
+  hireMercenary('WIZARD');
+  hireMercenary('HEALER');
+
+  if (promptCount !== 1) {
+    console.error('expected prompt when hiring 4th mercenary');
+    process.exit(1);
+  }
+
+  if (gameState.mercenaries.length !== 3) {
+    console.error('mercenary count should remain 3 after replacement');
+    process.exit(1);
+  }
+}
+
+run().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- enforce mercenary limit based on total count instead of only alive mercenaries
- prompt to dismiss any mercenary when limit reached and remove from array
- add a regression test to ensure a replacement is requested when trying to hire a fourth mercenary

## Testing
- `node tests/mercenaryFollow.test.js`
- `node tests/hireMercenaryReplacement.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68410f365e088327ac8132158e004233