### PR TITLE
Randomize exit location

### DIFF
--- a/index.html
+++ b/index.html
@@ -1452,8 +1452,12 @@ function healTarget(healer, target) {
                 gameState.player.inventory.push(starterPotion);
             }
 
-            const exitX = size - 2;
-            const exitY = size - 2;
+            let exitX, exitY;
+            do {
+                exitX = Math.floor(Math.random() * size);
+                exitY = Math.floor(Math.random() * size);
+            } while (gameState.dungeon[exitY][exitX] !== 'empty' || (exitX === 1 && exitY === 1));
+
             gameState.exitLocation = { x: exitX, y: exitY };
             gameState.dungeon[exitY][exitX] = 'exit';
 


### PR DESCRIPTION
## Summary
- randomize exit coordinates in `generateDungeon`
- ensure exit tile is placed at a random empty cell

## Testing
- `npm install`
- `node tests/mercenaryFollow.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68410f3889f48327a291e2ac91a05f99