### PR TITLE
Add Healing skill via new skillbook

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,12 +993,21 @@
                 price: 0,
                 level: 1,
                 icon: '📘'
+            },
+            healingBook: {
+                name: '📘 힐링 서적',
+                type: ITEM_TYPES.SKILLBOOK,
+                skill: 'Healing',
+                price: 0,
+                level: 1,
+                icon: '📘'
             }
         };
 
         const SKILL_DEFS = {
             Fireball: { name: 'Fireball', icon: '🔥', damage: 10, range: 5, magic: true, element: 'fire' },
-            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice' }
+            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice' },
+            Healing: { name: 'Healing', icon: '💖', heal: 10, range: 3, manaCost: 5 }
         };
 
         const ELEMENT_EMOJI = { fire: '🔥', ice: '❄️', lightning: '⚡' };
@@ -2892,6 +2901,37 @@ function healTarget(healer, target) {
                 return;
             }
             const skill = SKILL_DEFS[skillKey];
+            if (skill.heal) {
+                let target = null;
+                if (gameState.player.health < gameState.player.maxHealth) {
+                    target = gameState.player;
+                } else {
+                    for (const merc of gameState.activeMercenaries) {
+                        if (!merc.alive) continue;
+                        const d = getDistance(gameState.player.x, gameState.player.y, merc.x, merc.y);
+                        if (d <= skill.range && merc.health < merc.maxHealth) {
+                            target = merc;
+                            break;
+                        }
+                    }
+                }
+                if (!target) {
+                    addMessage('🎯 치유할 대상이 없습니다.', 'info');
+                    processTurn();
+                    return;
+                }
+                const healAmount = Math.min(skill.heal, target.maxHealth - target.health);
+                target.health += healAmount;
+                const name = target === gameState.player ? '플레이어' : target.name;
+                addMessage(`💖 ${name}을(를) ${healAmount} 회복했습니다.`, 'info');
+                if (target === gameState.player) {
+                    updateStats();
+                } else {
+                    updateMercenaryDisplay();
+                }
+                processTurn();
+                return;
+            }
             let target = null;
             let dist = Infinity;
             for (const monster of gameState.monsters) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/healingSkill.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/healingSkill.test.js
+++ b/tests/healingSkill.test.js
@@ -1,0 +1,50 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.updateSkillDisplay = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+  dom.window.processTurn = () => {};
+  dom.window.processProjectiles = () => {};
+
+  const { gameState, movePlayer, assignSkill, skill1Action, createItem } = dom.window;
+
+  gameState.player.health = Math.max(1, gameState.player.maxHealth - 5);
+
+  const book = createItem('healingBook', gameState.player.x + 1, gameState.player.y);
+  gameState.items.push(book);
+  gameState.dungeon[book.y][book.x] = 'item';
+
+  movePlayer(1, 0);
+  if (!gameState.player.skills.includes('Healing')) {
+    console.error('healing skill not learned');
+    process.exit(1);
+  }
+
+  gameState.player.health -= 5;
+  assignSkill(1, 'Healing');
+  skill1Action();
+
+  if (gameState.player.health <= gameState.player.maxHealth - 5) {
+    console.error('healing skill did not heal');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add Healing skill book item
- define Healing skill properties
- handle healing logic in `useSkill`
- include new Healing skill test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841990c99a8832792ae3a4484e16b35