### PR TITLE
Implement homing projectiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1225,6 +1225,14 @@ function healTarget(healer, target) {
         function processProjectiles() {
             const remaining = [];
             for (const proj of gameState.projectiles) {
+                const target = gameState.monsters.find(m => m.id === proj.targetId);
+                if (!target) {
+                    continue;
+                }
+
+                proj.dx = Math.sign(target.x - proj.x);
+                proj.dy = Math.sign(target.y - proj.y);
+
                 let nx = proj.x + proj.dx;
                 let ny = proj.y + proj.dy;
 
@@ -2871,7 +2879,16 @@ function healTarget(healer, target) {
 
             const dx = Math.sign(target.x - gameState.player.x);
             const dy = Math.sign(target.y - gameState.player.y);
-            gameState.projectiles.push({ x: gameState.player.x, y: gameState.player.y, dx, dy, rangeLeft: dist, icon: '➡️', element: null });
+            gameState.projectiles.push({
+                x: gameState.player.x,
+                y: gameState.player.y,
+                dx,
+                dy,
+                rangeLeft: dist,
+                icon: '➡️',
+                element: null,
+                targetId: target.id
+            });
             processTurn();
         }
 
@@ -2908,7 +2925,19 @@ function healTarget(healer, target) {
             }
             const dx = Math.sign(target.x - gameState.player.x);
             const dy = Math.sign(target.y - gameState.player.y);
-            gameState.projectiles.push({ x: gameState.player.x, y: gameState.player.y, dx, dy, rangeLeft: dist, icon: skill.icon, damage: skill.damage, magic: skill.magic, skill: skillKey, element: skill.element });
+            gameState.projectiles.push({
+                x: gameState.player.x,
+                y: gameState.player.y,
+                dx,
+                dy,
+                rangeLeft: dist,
+                icon: skill.icon,
+                damage: skill.damage,
+                magic: skill.magic,
+                skill: skillKey,
+                element: skill.element,
+                targetId: target.id
+            });
             processTurn();
         }
 


### PR DESCRIPTION
## Summary
- projectiles now store `targetId` for their intended monster
- projectiles home in on their target each step
- if the target dies before impact, the projectile is removed

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841990ba1e48327948b97d9f909b1d3