### PR TITLE
Add regeneration affixes and display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,12 +1007,14 @@
         const PREFIXES = [
             { name: 'Flaming', modifiers: { fireDamage: 2 } },
             { name: 'Sharp', modifiers: { attack: 1 } },
-            { name: 'Sturdy', modifiers: { defense: 1 } }
+            { name: 'Sturdy', modifiers: { defense: 1 } },
+            { name: 'Restorative', modifiers: { healthRegen: 1 } }
         ];
         const SUFFIXES = [
             { name: 'of Protection', modifiers: { defense: 2 } },
             { name: 'of Fury', modifiers: { attack: 2 } },
-            { name: 'of Vitality', modifiers: { maxHealth: 5 } }
+            { name: 'of Vitality', modifiers: { maxHealth: 5 } },
+            { name: 'of Clarity', modifiers: { manaRegen: 1 } }
         ];
 
         // 게임 상태
@@ -1197,6 +1199,8 @@ function healTarget(healer, target) {
             if (item.critChance !== undefined) stats.push(`치명+${item.critChance}`);
             if (item.magicPower !== undefined) stats.push(`마공+${item.magicPower}`);
             if (item.magicResist !== undefined) stats.push(`마방+${item.magicResist}`);
+            if (item.healthRegen !== undefined) stats.push(`HP회복+${item.healthRegen}`);
+            if (item.manaRegen !== undefined) stats.push(`MP회복+${item.manaRegen}`);
             return `${item.name}${stats.length ? ' (' + stats.join(', ') + ')' : ''}`;
         }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/affix.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/affix.test.js
+++ b/tests/affix.test.js
@@ -1,0 +1,51 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+
+  const prefixesLen = dom.window.eval('PREFIXES.length');
+  const suffixesLen = dom.window.eval('SUFFIXES.length');
+  const prefixIndex = dom.window.eval('PREFIXES.findIndex(p => p.modifiers.healthRegen)');
+  const suffixIndex = dom.window.eval('SUFFIXES.findIndex(s => s.modifiers.manaRegen)');
+
+  const seq = [
+    0.5, // id
+    0.1, // apply prefix
+    (prefixIndex + 0.1) / prefixesLen, // select restorative prefix
+    0.1, // apply suffix
+    (suffixIndex + 0.1) / suffixesLen // select clarity suffix
+  ];
+  const originalRandom = dom.window.Math.random;
+  dom.window.Math.random = () => seq.shift();
+
+  const { createItem } = dom.window;
+  const item = createItem('shortSword', 0, 0);
+
+  dom.window.Math.random = originalRandom;
+
+  if (item.prefix !== dom.window.eval(`PREFIXES[${prefixIndex}].name`) ||
+      item.suffix !== dom.window.eval(`SUFFIXES[${suffixIndex}].name`) ||
+      item.healthRegen !== 1 || item.manaRegen !== 1) {
+    console.error('affixes not applied correctly');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add Restorative and of Clarity affixes
- show health and mana regeneration in item tooltips
- verify items can roll new affixes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68419908e2f0832788f0f5eea0b724da