### PR TITLE
Fix revive scroll gold bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -2051,10 +2051,6 @@ function healTarget(healer, target) {
                 const idx = parseInt(choice, 10);
                 if (!isNaN(idx) && dead[idx]) {
                     const merc = dead[idx];
-                    const invIndex = gameState.player.inventory.findIndex(i => i.id === item.id);
-                    if (invIndex !== -1) {
-                        gameState.player.inventory.splice(invIndex, 1);
-                    }
                     reviveMercenary(merc);
                 }
                 return;


### PR DESCRIPTION
## Summary
- fix bug causing mercenary revival via revive scroll to still charge gold

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6841a62c57508327af45e630802a5df0