### PR TITLE
Add regen item modifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,12 +1007,14 @@
         const PREFIXES = [
             { name: 'Flaming', modifiers: { fireDamage: 2 } },
             { name: 'Sharp', modifiers: { attack: 1 } },
-            { name: 'Sturdy', modifiers: { defense: 1 } }
+            { name: 'Sturdy', modifiers: { defense: 1 } },
+            { name: 'Refreshing', modifiers: { healthRegen: 1 } }
         ];
         const SUFFIXES = [
             { name: 'of Protection', modifiers: { defense: 2 } },
             { name: 'of Fury', modifiers: { attack: 2 } },
-            { name: 'of Vitality', modifiers: { maxHealth: 5 } }
+            { name: 'of Vitality', modifiers: { maxHealth: 5 } },
+            { name: 'of Wisdom', modifiers: { manaRegen: 1 } }
         ];
 
         // 게임 상태
@@ -1194,11 +1196,13 @@ function healTarget(healer, target) {
             if (item.iceDamage !== undefined) stats.push(`❄️+${item.iceDamage}`);
             if (item.lightningDamage !== undefined) stats.push(`⚡+${item.lightningDamage}`);
             if (item.maxHealth !== undefined && item.type !== ITEM_TYPES.POTION && item.type !== ITEM_TYPES.REVIVE) stats.push(`HP+${item.maxHealth}`);
+            if (item.healthRegen !== undefined) stats.push(`HP회복+${item.healthRegen}`);
             if (item.accuracy !== undefined) stats.push(`명중+${item.accuracy}`);
             if (item.evasion !== undefined) stats.push(`회피+${item.evasion}`);
             if (item.critChance !== undefined) stats.push(`치명+${item.critChance}`);
             if (item.magicPower !== undefined) stats.push(`마공+${item.magicPower}`);
             if (item.magicResist !== undefined) stats.push(`마방+${item.magicResist}`);
+            if (item.manaRegen !== undefined) stats.push(`마나회복+${item.manaRegen}`);
             return `${item.name}${stats.length ? ' (' + stats.join(', ') + ')' : ''}`;
         }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/prefixSuffix.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -1,0 +1,48 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+
+  const { createItem, formatItem, PREFIXES, SUFFIXES } = dom.window;
+
+  const seq = [0, 0, 0.99, 0, 0.99];
+  const origRandom = dom.window.Math.random;
+  dom.window.Math.random = () => seq.shift() ?? origRandom();
+
+  const item = createItem('shortSword', 0, 0);
+
+  dom.window.Math.random = origRandom;
+
+  if (item.prefix !== 'Refreshing' || item.suffix !== 'of Wisdom') {
+    console.error('prefix or suffix not applied');
+    process.exit(1);
+  }
+  if (item.healthRegen !== 1 || item.manaRegen !== 1) {
+    console.error('modifiers not applied');
+    process.exit(1);
+  }
+  const desc = formatItem(item);
+  if (!desc.includes('HP') || !desc.includes('마나')) {
+    console.error('formatItem missing regen info');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add refreshing and wisdom modifiers for prefixes/suffixes
- display health/mana regen stats on items
- add tests for new modifiers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a72afb3c83279b10be2f67b39f5d