### PR TITLE
Add magic staff item with prefix/suffix support

### DIFF
--- a/index.html
+++ b/index.html
@@ -907,6 +907,15 @@
                 level: 3,
                 icon: '✨'
             },
+            magicStaff: {
+                name: '🔮 마법 지팡이',
+                type: ITEM_TYPES.WEAPON,
+                magicPower: 4,
+                manaRegen: 1,
+                price: 40,
+                level: 2,
+                icon: '🔮'
+            },
             leatherArmor: {
                 name: '🛡️ 가죽 갑옷',
                 type: ITEM_TYPES.ARMOR,
@@ -2389,7 +2398,7 @@ function healTarget(healer, target) {
                         updateStats();
                         
                         if (monster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
+                            const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
                             const bossItem = createItem(bossItemKey, newX, newY);
@@ -2761,7 +2770,7 @@ function healTarget(healer, target) {
                         updateStats();
                         
                         if (nearestMonster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
+                            const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
                             const bossItem = createItem(bossItemKey, nearestMonster.x, nearestMonster.y);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicStaff.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/magicStaff.test.js
+++ b/tests/magicStaff.test.js
@@ -1,0 +1,39 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.updateSkillDisplay = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+
+  dom.window.Math.random = () => 0.1;
+
+  const { createItem } = dom.window;
+  const item = createItem('magicStaff', 0, 0);
+
+  if (item.prefix !== 'Flaming' || item.suffix !== 'of Protection') {
+    console.error('prefix or suffix not applied');
+    process.exit(1);
+  }
+  if (item.fireDamage !== 2 || item.defense !== 2) {
+    console.error('modifiers not applied');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- introduce `magicStaff` weapon with magic power
- allow bosses to drop the new staff
- execute new tests via npm script
- add test ensuring prefixes/suffixes modify the staff

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a72e71708327bed69f07c2fef113