### PR TITLE
Add Healing skill and skillbook

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,12 +993,21 @@
                 price: 0,
                 level: 1,
                 icon: '📘'
+            },
+            healingBook: {
+                name: '📘 힐링 서적',
+                type: ITEM_TYPES.SKILLBOOK,
+                skill: 'Healing',
+                price: 0,
+                level: 1,
+                icon: '📘'
             }
         };
 
         const SKILL_DEFS = {
             Fireball: { name: 'Fireball', icon: '🔥', damage: 10, range: 5, magic: true, element: 'fire', manaCost: 3 },
-            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice', manaCost: 2 }
+            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice', manaCost: 2 },
+            Healing: { name: 'Healing', icon: '💖', heal: 10, manaCost: 3 }
         };
 
         const ELEMENT_EMOJI = { fire: '🔥', ice: '❄️', lightning: '⚡' };
@@ -2945,6 +2954,19 @@ function healTarget(healer, target) {
             const skill = SKILL_DEFS[skillKey];
             if (gameState.player.mana < skill.manaCost) {
                 addMessage('마나가 부족합니다.', 'info');
+                processTurn();
+                return;
+            }
+            if (skill.heal) {
+                const healAmount = Math.min(skill.heal, gameState.player.maxHealth - gameState.player.health);
+                if (healAmount > 0) {
+                    gameState.player.health += healAmount;
+                    addMessage(`💚 ${skill.name} 스킬로 ${healAmount} 체력을 회복했습니다.`, 'info');
+                    updateStats();
+                } else {
+                    addMessage('❤️ 체력이 이미 가득 찼습니다.', 'info');
+                }
+                gameState.player.mana -= skill.manaCost;
                 processTurn();
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/healingSkill.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/healingSkill.test.js
+++ b/tests/healingSkill.test.js
@@ -1,0 +1,52 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.updateSkillDisplay = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+  dom.window.processTurn = () => {};
+  dom.window.processProjectiles = () => {};
+
+  const { gameState, movePlayer, assignSkill, skill1Action, createItem } = dom.window;
+
+  const sb = createItem('healingBook', gameState.player.x + 1, gameState.player.y);
+  gameState.items.push(sb);
+  gameState.dungeon[sb.y][sb.x] = 'item';
+
+  movePlayer(1, 0);
+  if (!gameState.player.skills.includes('Healing')) {
+    console.error('healing skill not learned');
+    process.exit(1);
+  }
+
+  assignSkill(1, 'Healing');
+  gameState.player.health = 5;
+  const beforeMana = gameState.player.mana;
+  skill1Action();
+  if (gameState.player.health <= 5) {
+    console.error('healing skill did not heal');
+    process.exit(1);
+  }
+  if (gameState.player.mana !== beforeMana - 3) {
+    console.error('healing skill did not use mana');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add `Healing` skill definition
- add `healingBook` skillbook item
- support healing effects in `useSkill`
- test Healing skill behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a72e77b08327b5e07ab4f58c1654