### PR TITLE
Add mercenary skills and mana

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,7 +664,9 @@
                 baseMagicResist: 0,
                 role: 'tank',
                 description: '높은 체력과 방어력을 가진 근접 전투 용병',
-                cost: 50
+                cost: 50,
+                baseMana: 5,
+                skillPool: ['ChargeAttack', 'DoubleStrike']
             },
             ARCHER: {
                 name: '🏹 궁수',
@@ -679,7 +681,9 @@
                 baseMagicResist: 0,
                 role: 'ranged',
                 description: '원거리에서 적을 공격하는 용병',
-                cost: 60
+                cost: 60,
+                baseMana: 5,
+                skillPool: ['PowerShot', 'DoubleShot']
             },
             HEALER: {
                 name: '✚ 힐러',
@@ -694,7 +698,9 @@
                 baseMagicResist: 1,
                 role: 'support',
                 description: '아군을 치료하는 지원 용병',
-                cost: 70
+                cost: 70,
+                baseMana: 8,
+                skillPool: ['Heal']
             },
             WIZARD: {
                 name: '🔮 마법사',
@@ -709,7 +715,9 @@
                 baseMagicResist: 2,
                 role: 'caster',
                 description: '마법 공격에 특화된 용병',
-                cost: 80
+                cost: 80,
+                baseMana: 8,
+                skillPool: ['Fireball', 'Iceball']
             }
         };
 
@@ -998,7 +1006,12 @@
 
         const SKILL_DEFS = {
             Fireball: { name: 'Fireball', icon: '🔥', damage: 10, range: 5, magic: true, element: 'fire', manaCost: 3 },
-            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice', manaCost: 2 }
+            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice', manaCost: 2 },
+            ChargeAttack: { name: 'Charge Attack', icon: '💢', damage: 4, range: 1, manaCost: 2 },
+            DoubleStrike: { name: 'Double Strike', icon: '⚔️', damage: 5, range: 1, manaCost: 3 },
+            PowerShot: { name: 'Power Shot', icon: '🏹', damage: 6, range: 3, manaCost: 2 },
+            DoubleShot: { name: 'Double Shot', icon: '🏹', damage: 4, range: 3, manaCost: 3 },
+            Heal: { name: 'Heal', icon: '💚', heal: 6, range: 2, manaCost: 2 }
         };
 
         const ELEMENT_EMOJI = { fire: '🔥', ice: '❄️', lightning: '⚡' };
@@ -1135,7 +1148,40 @@ function healTarget(healer, target) {
                 const name = target === gameState.player ? '플레이어' : target.name;
                 addMessage(`💚 ${healer.name}이(가) ${name}을(를) ${healAmount} 회복했습니다.`, 'mercenary');
                 return true;
+}
+
+        function useMercenarySkill(mercenary, skillKey, target) {
+            const skill = SKILL_DEFS[skillKey];
+            if (!skill || mercenary.mana < skill.manaCost) return false;
+            if (skill.heal) {
+                if (getDistance(mercenary.x, mercenary.y, target.x, target.y) > skill.range) return false;
+                const healAmount = Math.min(skill.heal, target.maxHealth - target.health);
+                if (healAmount <= 0) return false;
+                mercenary.mana -= skill.manaCost;
+                target.health += healAmount;
+                const name = target === gameState.player ? '플레이어' : target.name;
+                addMessage(`${skill.icon} ${mercenary.name}이(가) ${name}을(를) ${healAmount} 회복했습니다.`, 'mercenary');
+                return true;
+            } else {
+                if (getDistance(mercenary.x, mercenary.y, target.x, target.y) > skill.range) return false;
+                mercenary.mana -= skill.manaCost;
+                let totalAttack = mercenary.attack + (mercenary.equipped && mercenary.equipped.weapon ? mercenary.equipped.weapon.attack : 0);
+                totalAttack += skill.damage || 0;
+                const result = performAttack(mercenary, target, { attackValue: totalAttack, magic: skill.magic, element: skill.element });
+                if (!result.hit) {
+                    addMessage(`❌ ${mercenary.name}의 ${skill.name}이 빗나갔습니다!`, 'mercenary');
+                } else {
+                    const critMsg = result.crit ? ' (치명타!)' : '';
+                    let dmgStr = result.baseDamage;
+                    if (result.elementDamage) {
+                        const emoji = ELEMENT_EMOJI[result.element] || '';
+                        dmgStr = `${result.baseDamage}+${emoji}${result.elementDamage}`;
+                    }
+                    addMessage(`${skill.icon} ${mercenary.name}이(가) ${target.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, 'mercenary');
+                }
+                return true;
             }
+        }
             return false;
         }
 
@@ -1861,6 +1907,11 @@ function healTarget(healer, target) {
             }
 
             const mercenary = createMercenary(type, -1, -1);
+            const pool = MERCENARY_TYPES[type].skillPool || [];
+            if (pool.length) {
+                const sk = pool[Math.floor(Math.random() * pool.length)];
+                mercenary.skills.push(sk);
+            }
 
             const activeCount = gameState.activeMercenaries.filter(m => m.alive).length;
             if (activeCount < 3) {
@@ -1939,6 +1990,9 @@ function healTarget(healer, target) {
                 expNeeded: 15,
                 alive: true,
                 hasActed: false,
+                maxMana: mercType.baseMana || 5,
+                mana: mercType.baseMana || 5,
+                skills: [],
                 traits: traits,
                 equipped: {
                     weapon: null,
@@ -2664,6 +2718,9 @@ function healTarget(healer, target) {
                 renderDungeon();
             });
             gameState.player.mana = Math.min(gameState.player.maxMana, gameState.player.mana + 1);
+            gameState.activeMercenaries.forEach(m => {
+                m.mana = Math.min(m.maxMana, (m.mana || 0) + 1);
+            });
             updateStats();
         }
 
@@ -2685,18 +2742,31 @@ function healTarget(healer, target) {
             
             // 힐러는 치료 우선
             if (mercenary.role === 'support') {
-                if (gameState.player.health < gameState.player.maxHealth * 0.7) {
-                    if (getDistance(mercenary.x, mercenary.y, gameState.player.x, gameState.player.y) <= 2) {
+                const healSkill = mercenary.skills[0];
+                if (healSkill) {
+                    if (gameState.player.health < gameState.player.maxHealth * 0.7) {
+                        if (useMercenarySkill(mercenary, healSkill, gameState.player)) {
+                            mercenary.hasActed = true;
+                            return;
+                        }
+                    }
+                    for (const otherMerc of gameState.activeMercenaries) {
+                        if (otherMerc !== mercenary && otherMerc.alive && otherMerc.health < otherMerc.maxHealth * 0.5) {
+                            if (useMercenarySkill(mercenary, healSkill, otherMerc)) {
+                                mercenary.hasActed = true;
+                                return;
+                            }
+                        }
+                    }
+                } else {
+                    if (gameState.player.health < gameState.player.maxHealth * 0.7) {
                         if (healTarget(mercenary, gameState.player)) {
                             mercenary.hasActed = true;
                             return;
                         }
                     }
-                }
-                
-                for (const otherMerc of gameState.activeMercenaries) {
-                    if (otherMerc !== mercenary && otherMerc.alive && otherMerc.health < otherMerc.maxHealth * 0.5) {
-                        if (getDistance(mercenary.x, mercenary.y, otherMerc.x, otherMerc.y) <= 2) {
+                    for (const otherMerc of gameState.activeMercenaries) {
+                        if (otherMerc !== mercenary && otherMerc.alive && otherMerc.health < otherMerc.maxHealth * 0.5) {
                             if (healTarget(mercenary, otherMerc)) {
                                 mercenary.hasActed = true;
                                 return;
@@ -2727,24 +2797,30 @@ function healTarget(healer, target) {
                 const attackRange = mercenary.role === 'ranged' ? 3 :
                                     mercenary.role === 'caster' ? 2 : 1;
                 if (nearestDistance <= attackRange) {
-                    // 공격 (장비 보너스 적용)
-                    let totalAttack = mercenary.attack;
-                    if (mercenary.equipped && mercenary.equipped.weapon) {
-                        totalAttack += mercenary.equipped.weapon.attack;
-                    }
-                    
-                    const result = performAttack(mercenary, nearestMonster, { attackValue: totalAttack });
-                    if (!result.hit) {
-                        addMessage(`❌ ${mercenary.name}의 공격이 빗나갔습니다!`, "mercenary");
+                    const skillKey = mercenary.skills[0];
+                    if (skillKey && !SKILL_DEFS[skillKey].heal && mercenary.mana >= SKILL_DEFS[skillKey].manaCost && nearestDistance <= SKILL_DEFS[skillKey].range) {
+                        useMercenarySkill(mercenary, skillKey, nearestMonster);
                     } else {
-                        const critMsg = result.crit ? ' (치명타!)' : '';
-                        let dmgStr = result.baseDamage;
-                        if (result.elementDamage) {
-                            const emoji = ELEMENT_EMOJI[result.element] || '';
-                            dmgStr = `${result.baseDamage}+${emoji}${result.elementDamage}`;
+                        // 공격 (장비 보너스 적용)
+                        let totalAttack = mercenary.attack;
+                        if (mercenary.equipped && mercenary.equipped.weapon) {
+                            totalAttack += mercenary.equipped.weapon.attack;
                         }
-                        addMessage(`⚔️ ${mercenary.name}이(가) ${nearestMonster.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, "mercenary");
+
+                        const result = performAttack(mercenary, nearestMonster, { attackValue: totalAttack });
+                        if (!result.hit) {
+                            addMessage(`❌ ${mercenary.name}의 공격이 빗나갔습니다!`, "mercenary");
+                        } else {
+                            const critMsg = result.crit ? ' (치명타!)' : '';
+                            let dmgStr = result.baseDamage;
+                            if (result.elementDamage) {
+                                const emoji = ELEMENT_EMOJI[result.element] || '';
+                                dmgStr = `${result.baseDamage}+${emoji}${result.elementDamage}`;
+                            }
+                            addMessage(`⚔️ ${mercenary.name}이(가) ${nearestMonster.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, "mercenary");
+                        }
                     }
+
                     
                     if (nearestMonster.health <= 0) {
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary");


### PR DESCRIPTION
## Summary
- add skill pools for each mercenary type
- grant mercenaries their own mana and skill list on creation
- randomly assign a skill when hiring
- expand SKILL_DEFS with mercenary abilities
- implement useMercenarySkill and integrate into mercenary AI
- regenerate mana for mercenaries each turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a72fa0648327a091ed3d321c62f2