### PR TITLE
Update regen labels in formatItem

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,7 +1212,7 @@ function healTarget(healer, target) {
             if (item.critChance !== undefined) stats.push(`치명+${item.critChance}`);
             if (item.magicPower !== undefined) stats.push(`마공+${item.magicPower}`);
             if (item.magicResist !== undefined) stats.push(`마방+${item.magicResist}`);
-            if (item.manaRegen !== undefined) stats.push(`마나회복+${item.manaRegen}`);
+            if (item.manaRegen !== undefined) stats.push(`MP회복+${item.manaRegen}`);
             return `${item.name}${stats.length ? ' (' + stats.join(', ') + ')' : ''}`;
         }
 

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -39,7 +39,7 @@ async function run() {
     process.exit(1);
   }
   const desc = formatItem(item);
-  if (!desc.includes('HP') || !desc.includes('마나')) {
+  if (!desc.includes('HP회복+') || !desc.includes('MP회복+')) {
     console.error('formatItem missing regen info');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- add missing mana regen label with `MP회복+`
- update prefix/suffix test expectations

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841abe8b6148327b6879b44839e0033