### PR TITLE
Add magic staff item

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,6 +915,15 @@
                 level: 3,
                 icon: '✨'
             },
+            magicStaff: {
+                name: '🔮 마법 지팡이',
+                type: ITEM_TYPES.WEAPON,
+                magicPower: 3,
+                manaRegen: 1,
+                price: 30,
+                level: 2,
+                icon: '🔮'
+            },
             leatherArmor: {
                 name: '🛡️ 가죽 갑옷',
                 type: ITEM_TYPES.ARMOR,
@@ -2422,7 +2431,7 @@ function healTarget(healer, target) {
                         updateStats();
                         
                         if (monster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
+                            const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
                             const bossItem = createItem(bossItemKey, newX, newY);
@@ -2798,7 +2807,7 @@ function healTarget(healer, target) {
                         updateStats();
                         
                         if (nearestMonster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
+                            const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
                             const bossItem = createItem(bossItemKey, nearestMonster.x, nearestMonster.y);


### PR DESCRIPTION
## Summary
- add `magicStaff` weapon with magic power and mana regen
- allow bosses to drop the new staff

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841abef1ac08327a291fde76cbe4dd8