### PR TITLE
Add Healing skill and update skill usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,12 +1001,21 @@
                 price: 0,
                 level: 1,
                 icon: '📘'
+            },
+            healingBook: {
+                name: '📘 힐링 서적',
+                type: ITEM_TYPES.SKILLBOOK,
+                skill: 'Healing',
+                price: 0,
+                level: 1,
+                icon: '📘'
             }
         };
 
         const SKILL_DEFS = {
             Fireball: { name: 'Fireball', icon: '🔥', damage: 10, range: 5, magic: true, element: 'fire', manaCost: 3 },
-            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice', manaCost: 2 }
+            Iceball: { name: 'Iceball', icon: '❄️', damage: 8, range: 5, magic: true, element: 'ice', manaCost: 2 },
+            Healing: { name: 'Healing', icon: '💖', heal: 10, manaCost: 3 }
         };
 
         const HEAL_MANA_COST = 2;
@@ -2973,7 +2982,7 @@ function healTarget(healer, target) {
             useSkill(skill);
         }
 
-        function useSkill(skillKey) {
+       function useSkill(skillKey) {
             if (!skillKey) {
                 addMessage('스킬이 설정되어 있지 않습니다.', 'info');
                 processTurn();
@@ -2982,6 +2991,20 @@ function healTarget(healer, target) {
             const skill = SKILL_DEFS[skillKey];
             if (gameState.player.mana < skill.manaCost) {
                 addMessage('마나가 부족합니다.', 'info');
+                processTurn();
+                return;
+            }
+            if (skill.heal !== undefined) {
+                const healAmount = Math.min(skill.heal, gameState.player.maxHealth - gameState.player.health);
+                if (healAmount <= 0) {
+                    addMessage('❤️ 체력이 이미 가득 찼습니다.', 'info');
+                    processTurn();
+                    return;
+                }
+                gameState.player.mana -= skill.manaCost;
+                gameState.player.health += healAmount;
+                addMessage(`💚 ${skill.name}으로 ${healAmount} 체력을 회복했습니다.`, 'info');
+                updateStats();
                 processTurn();
                 return;
             }


### PR DESCRIPTION
## Summary
- add Healing skill with mana cost and heal amount
- create healingBook item that teaches Healing
- allow useSkill to heal the player when skill.heal is present

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841abf1a1108327870ee80231d96503