### PR TITLE
Add mercenary skill usage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/prefixSuffix.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/prefixSuffix.test.js && node tests/mercenarySkill.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -1,0 +1,76 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  // stub out visual functions
+  dom.window.updateStats = () => {};
+  dom.window.updateMercenaryDisplay = () => {};
+  dom.window.updateInventoryDisplay = () => {};
+  dom.window.renderDungeon = () => {};
+  dom.window.updateCamera = () => {};
+  dom.window.updateSkillDisplay = () => {};
+  dom.window.requestAnimationFrame = fn => fn();
+
+  const {
+    hireMercenary,
+    createMonster,
+    processMercenaryTurn,
+    gameState
+  } = dom.window;
+
+  const MERCENARY_SKILLS = dom.window.eval('MERCENARY_SKILLS');
+
+  // create a simple empty dungeon
+  const size = 5;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.dungeon[1][1] = 'empty';
+
+  hireMercenary('WIZARD');
+  const merc = gameState.activeMercenaries[0];
+
+  if (!MERCENARY_SKILLS[merc.skill]) {
+    console.error('invalid mercenary skill');
+    process.exit(1);
+  }
+
+  const monsterX = merc.x + 1 < size ? merc.x + 1 : merc.x - 1;
+  const monsterY = merc.y;
+  const monster = createMonster('ZOMBIE', monsterX, monsterY);
+  monster.health = monster.maxHealth = 999; // prevent death side-effects
+  gameState.monsters.push(monster);
+  gameState.dungeon[monsterY][monsterX] = 'monster';
+
+  const skillCost = MERCENARY_SKILLS[merc.skill].manaCost;
+  merc.mana = skillCost;
+  const initialMana = merc.mana;
+  const origRandom = dom.window.Math.random;
+  dom.window.Math.random = () => 0;
+
+  processMercenaryTurn(merc);
+
+  dom.window.Math.random = origRandom;
+
+  const expected = Math.min(merc.maxMana, initialMana + merc.manaRegen) - skillCost;
+  if (merc.mana !== expected) {
+    console.error('mana not deducted by skill cost');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add `mercenarySkill.test.js` to ensure mercenary skills deduct mana
- include the new test in npm script

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b8111fd48327bb84d24ef0f3c219