### PR TITLE
Fix hireMercenary mana fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -2015,8 +2015,6 @@ function healTarget(healer, target) {
                     return;
                 }
                 setMercenaryLevel(mercenary, removed.level);
-                mercenary.maxMana = MERCENARY_TYPES[type].baseMaxMana || 0;
-                mercenary.mana = mercenary.maxMana;
                 gameState.activeMercenaries[index] = mercenary;
                 removed.x = -1;
                 removed.y = -1;


### PR DESCRIPTION
## Summary
- remove redundant maxMana/mana reset in `hireMercenary`
- rely on `createMercenary` initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b81459f083278bf3ac38f19db3a6