### PR TITLE
Implement dash for ChargeAttack

### DIFF
--- a/index.html
+++ b/index.html
@@ -1032,7 +1032,7 @@
 
         // 용병 전용 스킬 정의
         const MERCENARY_SKILLS = {
-            ChargeAttack: { name: 'Charge Attack', icon: '⚡', range: 2, manaCost: 2, multiplier: 1.5 },
+            ChargeAttack: { name: 'Charge Attack', icon: '⚡', range: 2, manaCost: 2, multiplier: 1.5, dashRange: 4 },
             DoubleStrike: { name: 'Double Strike', icon: '🔪', range: 1, manaCost: 3 },
             Heal: { name: 'Heal', icon: '✨', range: 2, manaCost: 2 },
             Fireball: { name: 'Fireball', icon: '🔥', range: 4, manaCost: 3, damage: 8, magic: true, element: 'fire' }
@@ -2901,6 +2901,98 @@ function healTarget(healer, target, skillInfo) {
                         mercenary.hasActed = true;
                         return;
                     }
+                } else if (skillKey === 'ChargeAttack' && nearestMonster && nearestDistance <= skillInfo.dashRange && hasLineOfSight(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y)) {
+                    let attackValue = mercenary.attack;
+                    if (mercenary.equipped && mercenary.equipped.weapon) {
+                        attackValue += mercenary.equipped.weapon.attack;
+                    }
+                    attackValue = Math.floor(attackValue * skillInfo.multiplier);
+
+                    const path = findPath(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y);
+                    let destX = mercenary.x;
+                    let destY = mercenary.y;
+                    if (path && path.length > 1) {
+                        const maxSteps = Math.min(skillInfo.dashRange, path.length - 2);
+                        for (let i = 1; i <= maxSteps; i++) {
+                            const step = path[i];
+                            const blocked =
+                                gameState.dungeon[step.y][step.x] === 'wall' ||
+                                gameState.dungeon[step.y][step.x] === 'monster' ||
+                                (step.x === gameState.player.x && step.y === gameState.player.y) ||
+                                gameState.activeMercenaries.some(m => m !== mercenary && m.alive && m.x === step.x && m.y === step.y);
+                            if (blocked) {
+                                break;
+                            }
+                            destX = step.x;
+                            destY = step.y;
+                        }
+                        mercenary.nextX = destX;
+                        mercenary.nextY = destY;
+                    }
+
+                    const hits = 1;
+                    const icon = skillInfo.icon;
+                    const result = performAttack(mercenary, nearestMonster, { attackValue });
+                    if (!result.hit) {
+                        addMessage(`❌ ${mercenary.name}의 ${skillInfo.name}이 빗나갔습니다!`, "mercenary");
+                    } else {
+                        const critMsg = result.crit ? ' (치명타!)' : '';
+                        let dmgStr = result.baseDamage;
+                        if (result.elementDamage) {
+                            const emoji = ELEMENT_EMOJI[result.element] || '';
+                            dmgStr = `${result.baseDamage}+${emoji}${result.elementDamage}`;
+                        }
+                        addMessage(`${icon} ${mercenary.name}이(가) ${nearestMonster.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, "mercenary");
+                    }
+
+                    if (nearestMonster.health <= 0) {
+                        addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary");
+
+                        const mercExp = Math.floor(nearestMonster.exp * 0.6);
+                        const playerExp = Math.floor(nearestMonster.exp * 0.4);
+
+                        mercenary.exp += mercExp;
+                        gameState.player.exp += playerExp;
+                        gameState.player.gold += nearestMonster.gold;
+
+                        checkMercenaryLevelUp(mercenary);
+                        checkLevelUp();
+                        updateStats();
+
+                        if (nearestMonster.special === 'boss') {
+                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
+                            if (Math.random() < 0.2) bossItems.push('reviveScroll');
+                            const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
+                            const bossItem = createItem(bossItemKey, nearestMonster.x, nearestMonster.y);
+                            gameState.items.push(bossItem);
+                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
+                        } else if (Math.random() < nearestMonster.lootChance) {
+                            const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
+                            const availableItems = itemKeys.filter(key =>
+                                ITEMS[key].level <= Math.ceil(gameState.floor / 2 + 1)
+                            );
+                            let randomItemKey = availableItems[Math.floor(Math.random() * availableItems.length)];
+                            if (Math.random() < 0.1 && ITEMS.reviveScroll.level <= Math.ceil(gameState.floor / 2 + 1)) {
+                                randomItemKey = 'reviveScroll';
+                            }
+
+                            const droppedItem = createItem(randomItemKey, nearestMonster.x, nearestMonster.y);
+                            gameState.items.push(droppedItem);
+                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
+                        } else {
+                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
+                        }
+
+                        const monsterIndex = gameState.monsters.findIndex(m => m === nearestMonster);
+                        if (monsterIndex !== -1) {
+                            gameState.monsters.splice(monsterIndex, 1);
+                        }
+                    }
+                    mercenary.mana -= skillInfo.manaCost;
+                    mercenary.hasActed = true;
+                    return;
                 } else if (nearestMonster && nearestDistance <= skillInfo.range && hasLineOfSight(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y)) {
                     let attackValue = mercenary.attack;
                     if (mercenary.equipped && mercenary.equipped.weapon) {


### PR DESCRIPTION
## Summary
- add `dashRange` to ChargeAttack skill
- dash toward monsters up to `dashRange` before attacking

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841be0f3e748327ac219a357e8d3298