### PR TITLE
Update mercenary mana display

### DIFF
--- a/index.html
+++ b/index.html
@@ -2850,6 +2850,7 @@ function healTarget(healer, target, skillInfo) {
                             : healTarget(mercenary, gameState.player);
                         if (healed) {
                             mercenary.mana -= manaCost;
+                            updateMercenaryDisplay();
                             mercenary.hasActed = true;
                             return;
                         }
@@ -2864,6 +2865,7 @@ function healTarget(healer, target, skillInfo) {
                                 : healTarget(mercenary, otherMerc);
                             if (healed) {
                                 mercenary.mana -= manaCost;
+                                updateMercenaryDisplay();
                                 mercenary.hasActed = true;
                                 return;
                             }
@@ -2906,6 +2908,7 @@ function healTarget(healer, target, skillInfo) {
                     }
                     if (target && healTarget(mercenary, target, skillInfo)) {
                         mercenary.mana -= skillInfo.manaCost;
+                        updateMercenaryDisplay();
                         mercenary.hasActed = true;
                         return;
                     }
@@ -2999,6 +3002,7 @@ function healTarget(healer, target, skillInfo) {
                         }
                     }
                     mercenary.mana -= skillInfo.manaCost;
+                    updateMercenaryDisplay();
                     mercenary.hasActed = true;
                     return;
                 } else if (nearestMonster && nearestDistance <= skillInfo.range && hasLineOfSight(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y)) {
@@ -3077,6 +3081,7 @@ function healTarget(healer, target, skillInfo) {
                         }
                     }
                     mercenary.mana -= skillInfo.manaCost;
+                    updateMercenaryDisplay();
                     mercenary.hasActed = true;
                     return;
                 }


### PR DESCRIPTION
## Summary
- show mercenary mana drop immediately when skills are used by calling `updateMercenaryDisplay()`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c6c49ec08327aa882040e305594c