### PR TITLE
Add Iceball skill and ensure element damage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1036,7 +1036,7 @@
             DoubleStrike: { name: 'Double Strike', icon: '🔪', range: 1, manaCost: 3 },
             Heal: { name: 'Heal', icon: '✨', range: 2, manaCost: 2 },
             Fireball: { name: 'Fireball', icon: '🔥', range: 4, manaCost: 3, damage: 8, magic: true, element: 'fire' },
-            Iceball: { name: 'Iceball', icon: '❄️', range: 5, manaCost: 2, damage: 8, magic: true, element: 'ice' }
+            Iceball: { name: 'Iceball', icon: '❄️', range: 4, manaCost: 2, damage: 8, magic: true, element: 'ice' }
         };
 
         const MERCENARY_SKILL_SETS = {


### PR DESCRIPTION
## Summary
- update mercenary Iceball skill definition to use range 4
- keep wizard skill set including Iceball
- confirm elemental damage passed for Fireball/Iceball attacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c6d344a48327b7ed5c355834e665