### PR TITLE
Update trait tests

### DIFF
--- a/tests/traitEffects.test.js
+++ b/tests/traitEffects.test.js
@@ -44,35 +44,16 @@ async function run() {
   let result = performAttack(attacker, defender);
   assert.strictEqual(result.damage, 8);
 
-  // Relentless Hunter bonus damage when target bleeding
-  attacker = { attack: 10, critChance: 0, accuracy: 1, traits: ['집요한 사냥꾼'] };
-  defender = {
-    defense: 0,
-    evasion: 0,
-    traits: [],
-    bleedTurns: 2,
-    health: 20,
-    statusResistances: { poison:0, bleed:0, burn:0, freeze:0 },
-    elementResistances: { fire:0, ice:0, lightning:0, earth:0, light:0, dark:0 }
-  };
-  result = performAttack(attacker, defender);
-  assert.strictEqual(result.damage, 12);
+  // Mana Attunement boosts mana regeneration
+  const getStat = dom.window.getStat;
+  let character = { manaRegen: 1, traits: ['마력 조율자'], maxHealth: 10, health: 10 };
+  let regen = getStat(character, 'manaRegen');
+  assert.strictEqual(regen, 1.5);
 
-  // Stealth Blade inflicts bleed
-  attacker = { attack: 5, critChance: 0, accuracy: 1, traits: ['은밀한 칼날'] };
-  defender = {
-    defense: 0,
-    evasion: 0,
-    traits: [],
-    health: 20,
-    statusResistances: { poison:0, bleed:0, burn:0, freeze:0 },
-    elementResistances: { fire:0, ice:0, lightning:0, earth:0, light:0, dark:0 }
-  };
-  const origRandom = dom.window.Math.random;
-  dom.window.Math.random = () => 0;
-  result = performAttack(attacker, defender);
-  dom.window.Math.random = origRandom;
-  assert.ok(result.statusApplied && defender.bleedTurns === 3);
+  // Escapee's Sense raises evasion at low health
+  character = { evasion: 0, traits: ['도망자 감각'], maxHealth: 10, health: 2 };
+  let evasion = getStat(character, 'evasion');
+  assert.strictEqual(evasion, 0.2);
 
   // Mercenaries heal after moving to the next floor
   const merc = { maxHealth: 50, health: 25, alive: true, traits: [] };

--- a/tests/traits.test.js
+++ b/tests/traits.test.js
@@ -33,28 +33,21 @@ async function run() {
     '철벽',
     '의지의 불꽃',
     '마력 조율자',
-    '오크의 피',
-    '돌주먹',
-    '거산',
-    '장신',
-    '재빠름'
+    '맹공 돌진',
+    '집요한 사냥꾼',
+    '공허 지식자'
   ]);
   assert.deepStrictEqual(REACTIVE_TRAITS, [
     '복수의 피',
-    '도망자 감각',
-    '조용함'
+    '도망자 감각'
   ]);
   assert.deepStrictEqual(STATUS_TRAITS, [
     '은밀한 칼날',
     '구호의 손길',
-    '도발의 혼',
-    '불꽃의 혼',
-    '빙결의 혼'
+    '도발의 혼'
   ]);
   assert.deepStrictEqual(FIELD_TRAITS, [
-    '보물 감별사',
-    '재산 관리인',
-    '책벌레'
+    '보물 감별사'
   ]);
   assert.deepStrictEqual(SPECIAL_ACTION_TRAITS, []);
 


### PR DESCRIPTION
## Summary
- adjust expectations for updated trait arrays
- simplify trait effect tests to only verify active stat boosts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842797cc0e8832780677e2a881a2f29