### PR TITLE
Add star stats for mercenaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1558,11 +1558,11 @@
 
             const html = `
                 <h3>${merc.icon} ${merc.name} Lv.${merc.level}</h3>
-                <div>💪 힘: ${merc.strength}</div>
-                <div>🏃 민첩: ${merc.agility}</div>
-                <div>🛡 체력: ${merc.endurance}</div>
-                <div>🔮 집중: ${merc.focus}</div>
-                <div>📖 지능: ${merc.intelligence}</div>
+                <div>💪 힘: ${merc.strength} ${'★'.repeat(merc.stars.strength)}</div>
+                <div>🏃 민첩: ${merc.agility} ${'★'.repeat(merc.stars.agility)}</div>
+                <div>🛡 체력: ${merc.endurance} ${'★'.repeat(merc.stars.endurance)}</div>
+                <div>🔮 집중: ${merc.focus} ${'★'.repeat(merc.stars.focus)}</div>
+                <div>📖 지능: ${merc.intelligence} ${'★'.repeat(merc.stars.intelligence)}</div>
                 <hr>
                 <div>❤️ HP: ${merc.health}/${getStat(merc, 'maxHealth')}</div>
                 <div>🔋 MP: ${merc.mana}/${getStat(merc, 'maxMana')}</div>
@@ -1586,11 +1586,13 @@
             document.getElementById('mercenary-detail-content').innerHTML = html;
             document.getElementById('mercenary-detail-panel').style.display = 'block';
             gameState.gameRunning = false;
+            window.currentDetailMercenary = merc;
         }
 
         function hideMercenaryDetails() {
             document.getElementById('mercenary-detail-panel').style.display = 'none';
             gameState.gameRunning = true;
+            window.currentDetailMercenary = null;
         }
 
         function spawnMercenaryNearPlayer(mercenary) {
@@ -1910,13 +1912,19 @@ function killMonster(monster) {
             while (mercenary.exp >= mercenary.expNeeded) {
                 mercenary.exp -= mercenary.expNeeded;
                 mercenary.level += 1;
-                mercenary.endurance += 2;
-                mercenary.strength += 1;
+                mercenary.endurance += 2 + mercenary.stars.endurance * 0.5;
+                mercenary.strength += 1 + mercenary.stars.strength * 0.5;
+                mercenary.agility += 1 + mercenary.stars.agility * 0.5;
+                mercenary.focus += 1 + mercenary.stars.focus * 0.5;
+                mercenary.intelligence += 1 + mercenary.stars.intelligence * 0.5;
                 mercenary.health = getStat(mercenary, 'maxHealth');
                 mercenary.mana = getStat(mercenary, 'maxMana');
                 mercenary.expNeeded = Math.floor(mercenary.expNeeded * 1.5);
                 addMessage(`🎉 ${mercenary.name}의 레벨이 ${mercenary.level}이(가) 되었습니다!`, 'mercenary');
                 updateMercenaryDisplay();
+                if (window.currentDetailMercenary && window.currentDetailMercenary.id === mercenary.id) {
+                    showMercenaryDetails(mercenary);
+                }
             }
         }
 
@@ -2145,6 +2153,20 @@ function killMonster(monster) {
             renderDungeon();
         }
 
+        function generateStars() {
+            let stars;
+            do {
+                stars = {
+                    strength: Math.floor(Math.random() * 4),
+                    agility: Math.floor(Math.random() * 4),
+                    endurance: Math.floor(Math.random() * 4),
+                    focus: Math.floor(Math.random() * 4),
+                    intelligence: Math.floor(Math.random() * 4)
+                };
+            } while (Object.values(stars).reduce((a,b)=>a+b,0) > 9);
+            return stars;
+        }
+
         // 용병 생성 함수
         function createMercenary(type, x, y) {
             const mercType = MERCENARY_TYPES[type];
@@ -2165,6 +2187,7 @@ function killMonster(monster) {
                 x: x,
                 y: y,
                 level: 1,
+                stars: generateStars(),
                 endurance: endurance,
                 focus: focus,
                 strength: mercType.baseAttack,
@@ -3408,6 +3431,7 @@ function killMonster(monster) {
                 return;
             }
             const saved = JSON.parse(data);
+            delete saved.mercenaries;
             Object.assign(gameState, saved);
             if (saved.activeMercenaries) gameState.activeMercenaries = saved.activeMercenaries;
             else if (saved.mercenaries) gameState.activeMercenaries = saved.mercenaries;
@@ -3432,6 +3456,9 @@ function killMonster(monster) {
                     m.agility = Math.max(0, Math.round((m.accuracy - 0.7) / 0.02));
                     m.intelligence = m.magicPower;
                     m.baseDefense = m.defense - Math.floor(endurance * 0.1);
+                }
+                if (!m.stars) {
+                    m.stars = generateStars();
                 }
             };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/prefixSuffix.test.js && node tests/mercenarySkill.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/prefixSuffix.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/mercenaryStars.test.js
+++ b/tests/mercenaryStars.test.js
@@ -1,0 +1,64 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { hireMercenary, gameState, checkMercenaryLevelUp, showMercenaryDetails, saveGame, loadGame, localStorage } = win;
+
+  gameState.player.gold = 500;
+  hireMercenary('WARRIOR');
+  const merc = gameState.activeMercenaries[0];
+
+  const total = Object.values(merc.stars).reduce((a,b)=>a+b,0);
+  if (total > 9) {
+    console.error('star total exceeds 9');
+    process.exit(1);
+  }
+
+  showMercenaryDetails(merc);
+  const html = win.document.getElementById('mercenary-detail-content').innerHTML;
+  if (!html.includes('★'.repeat(merc.stars.strength))) {
+    console.error('stars not shown in details');
+    process.exit(1);
+  }
+
+  merc.stars = { strength: 2, agility: 0, endurance: 0, focus: 0, intelligence: 0 };
+  const prev = merc.strength;
+  merc.exp = merc.expNeeded;
+  checkMercenaryLevelUp(merc);
+  const expected = prev + 1 + merc.stars.strength * 0.5;
+  if (merc.strength !== expected) {
+    console.error('star growth not applied');
+    process.exit(1);
+  }
+
+  delete merc.stars;
+  saveGame();
+  loadGame();
+  const loaded = gameState.activeMercenaries[0];
+  const loadSum = Object.values(loaded.stars).reduce((a,b)=>a+b,0);
+  if (loadSum > 9) {
+    console.error('stars invalid after load');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add a star generation helper and store stars on mercenaries
- display star ratings in mercenary detail view
- adjust level up to scale with star counts and refresh open panel
- keep backward compatibility when loading older saves
- add tests for stars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f99c7558832786f93fe28d0ed911