### PR TITLE
Add click-based movement with path following

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,6 +1128,8 @@
             dungeonSize: 80,
             viewportSize: 25,
             camera: { x: 0, y: 0 },
+            autoMovePath: null,
+            autoMoveActive: false,
             gameRunning: true
         };
         window.gameState = gameState;
@@ -1958,6 +1960,13 @@ function killMonster(monster) {
             const merc = gameState.activeMercenaries.find(m => m.x === x && m.y === y && m.alive);
             if (merc) {
                 showMercenaryDetails(merc);
+                return;
+            }
+
+            const path = findPath(gameState.player.x, gameState.player.y, x, y);
+            if (path && path.length > 1) {
+                gameState.autoMovePath = path.slice(1);
+                autoMoveStep();
             }
         }
 
@@ -2762,6 +2771,9 @@ function killMonster(monster) {
         // 플레이어 이동
         function movePlayer(dx, dy) {
             if (!gameState.gameRunning) return;
+            if (!gameState.autoMoveActive) {
+                gameState.autoMovePath = null;
+            }
             
             const newX = gameState.player.x + dx;
             const newY = gameState.player.y + dy;
@@ -2900,6 +2912,24 @@ function killMonster(monster) {
             }
 
             processTurn();
+        }
+
+        function autoMoveStep() {
+            if (!gameState.autoMovePath || !gameState.autoMovePath.length) {
+                gameState.autoMovePath = null;
+                return;
+            }
+            const step = gameState.autoMovePath.shift();
+            const dx = step.x - gameState.player.x;
+            const dy = step.y - gameState.player.y;
+            gameState.autoMoveActive = true;
+            movePlayer(dx, dy);
+            gameState.autoMoveActive = false;
+            if (gameState.autoMovePath && gameState.autoMovePath.length && gameState.gameRunning) {
+                setTimeout(autoMoveStep, 100);
+            } else {
+                gameState.autoMovePath = null;
+            }
         }
 
         // 다음 층으로

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js"
+    "test": "node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/clickMovement.test.js
+++ b/tests/clickMovement.test.js
@@ -1,0 +1,46 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+  win.setTimeout = fn => fn();
+  win.showMonsterDetails = () => {};
+  win.showMercenaryDetails = () => {};
+
+  const { gameState, handleDungeonClick } = win;
+
+  const startX = gameState.player.x;
+  const startY = gameState.player.y;
+  for (let i = 1; i <= 3; i++) {
+    gameState.dungeon[startY][startX + i] = 'empty';
+  }
+  gameState.monsters = [];
+
+  const cell = { dataset: { x: String(startX + 3), y: String(startY) }, closest: () => cell };
+  handleDungeonClick({ target: cell });
+
+  if (gameState.player.x !== startX + 3 || gameState.player.y !== startY) {
+    console.error('player did not move to clicked tile');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- support automatic pathfinding movement when clicking on a tile
- stop automatic path when the player moves manually
- add test for click movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68450fd153f08327ab8328398fb7d431