### PR TITLE
Add Fire Nova and Ice Nova skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1036,6 +1036,22 @@
                 level: 1,
                 icon: '📘'
             },
+            fireNovaBook: {
+                name: '📘 파이어 노바 서적',
+                type: ITEM_TYPES.SKILLBOOK,
+                skill: 'FireNova',
+                price: 0,
+                level: 2,
+                icon: '📘'
+            },
+            iceNovaBook: {
+                name: '📘 아이스 노바 서적',
+                type: ITEM_TYPES.SKILLBOOK,
+                skill: 'IceNova',
+                price: 0,
+                level: 2,
+                icon: '📘'
+            },
             healingBook: {
                 name: '📘 힐링 서적',
                 type: ITEM_TYPES.SKILLBOOK,
@@ -1049,6 +1065,8 @@
         const SKILL_DEFS = {
             Fireball: { name: 'Fireball', icon: '🔥', damageDice: '1d10', range: 5, magic: true, element: 'fire', manaCost: 3 },
             Iceball: { name: 'Iceball', icon: '❄️', damageDice: '1d8', range: 5, magic: true, element: 'ice', manaCost: 2 },
+            FireNova: { name: 'Fire Nova', icon: '🔥', damageDice: '1d6', radius: 3, magic: true, element: 'fire', manaCost: 5 },
+            IceNova: { name: 'Ice Nova', icon: '❄️', damageDice: '1d6', radius: 3, magic: true, element: 'ice', manaCost: 4 },
             Healing: { name: 'Healing', icon: '💖', heal: 10, manaCost: 3 }
         };
 
@@ -3973,6 +3991,36 @@ function killMonster(monster) {
                 gameState.player.health += healAmount;
                 addMessage(`💚 ${skill.name}으로 ${formatNumber(healAmount)} 체력을 회복했습니다.`, 'info');
                 updateStats();
+                processTurn();
+                return;
+            }
+            if (skill.radius !== undefined) {
+                const targets = gameState.monsters.filter(m => getDistance(gameState.player.x, gameState.player.y, m.x, m.y) <= skill.radius);
+                if (targets.length === 0) {
+                    addMessage('🎯 사거리 내에 몬스터가 없습니다.', 'info');
+                    processTurn();
+                    return;
+                }
+                gameState.player.mana -= skill.manaCost;
+                targets.slice().forEach(monster => {
+                    const attackValue = rollDice(skill.damageDice) + getStat(gameState.player, 'magicPower');
+                    const result = performAttack(gameState.player, monster, { attackValue, magic: skill.magic, element: skill.element, damageDice: skill.damageDice, status: gameState.player.equipped.weapon && gameState.player.equipped.weapon.status });
+                    const detail = `hit roll ${result.hitRoll} vs ${result.defenseTarget} → ${result.hit ? 'hit' : 'miss'}${result.hit ? '; damage roll ' + result.damageRoll : ''}`;
+                    if (!result.hit) {
+                        addMessage(`❌ ${monster.name}에게 ${skill.name}이 빗나갔습니다!`, 'combat', detail);
+                    } else {
+                        const critMsg = result.crit ? ' (치명타!)' : '';
+                        let dmgStr = formatNumber(result.baseDamage);
+                        if (result.elementDamage) {
+                            const emoji = ELEMENT_EMOJI[result.element] || '';
+                            dmgStr = `${formatNumber(result.baseDamage)}+${emoji}${formatNumber(result.elementDamage)}`;
+                        }
+                        addMessage(`${skill.icon} ${monster.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, 'combat', detail);
+                    }
+                    if (monster.health <= 0) {
+                        killMonster(monster);
+                    }
+                });
                 processTurn();
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/skillbook.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/nova.test.js
+++ b/tests/nova.test.js
@@ -1,0 +1,87 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const size = 5;
+  const { assignSkill, skill1Action, createMonster, createItem, gameState, getStat } = win;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.dungeon[1][1] = 'empty';
+
+  // Test Fire Nova
+  gameState.player.skills.push('FireNova');
+  assignSkill(1, 'FireNova');
+  const fireWeapon = createItem('shortSword', 0, 0);
+  fireWeapon.fireDamage = 2;
+  gameState.player.equipped.weapon = fireWeapon;
+  gameState.player.intelligence = 4;
+
+  const m1 = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  const m2 = createMonster('ZOMBIE', gameState.player.x, gameState.player.y + 2);
+  gameState.monsters.push(m1, m2);
+  gameState.dungeon[m1.y][m1.x] = 'monster';
+  gameState.dungeon[m2.y][m2.x] = 'monster';
+
+  let captured = [];
+  win.performAttack = (att, def, opts) => { captured.push(opts); return { hit: true, crit: false, baseDamage: 0, elementDamage: 0 }; };
+  win.rollDice = () => 4;
+  skill1Action();
+
+  const expected = 4 + getStat(gameState.player, 'magicPower');
+  const relevantFire = captured.filter(c => c.element);
+  if (relevantFire.length !== 2 || relevantFire.some(c => c.attackValue !== expected || c.element !== 'fire')) {
+    console.error('fire nova incorrect', JSON.stringify(captured));
+    process.exit(1);
+  }
+
+  // Test Ice Nova
+  captured = [];
+  gameState.monsters = [];
+  gameState.dungeon[m1.y][m1.x] = 'empty';
+  gameState.dungeon[m2.y][m2.x] = 'empty';
+  const i1 = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  const i2 = createMonster('ZOMBIE', gameState.player.x, gameState.player.y + 2);
+  gameState.monsters.push(i1, i2);
+  gameState.dungeon[i1.y][i1.x] = 'monster';
+  gameState.dungeon[i2.y][i2.x] = 'monster';
+  gameState.player.skills.push('IceNova');
+  assignSkill(1, 'IceNova');
+  const iceWeapon = createItem('shortSword', 0, 0);
+  iceWeapon.iceDamage = 2;
+  gameState.player.equipped.weapon = iceWeapon;
+  win.rollDice = () => 5;
+  skill1Action();
+
+  const expectedIce = 5 + getStat(gameState.player, 'magicPower');
+  const relevantIce = captured.filter(c => c.element);
+  if (relevantIce.length !== 2 || relevantIce.some(c => c.attackValue !== expectedIce || c.element !== 'ice')) {
+    console.error('ice nova incorrect', JSON.stringify(captured));
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- introduce new skillbooks for Fire Nova and Ice Nova
- implement Fire Nova and Ice Nova in SKILL_DEFS
- extend skill usage to support area-of-effect radius damage
- add unit tests covering nova skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68452e361bc883279bbedfce75e091a6