### PR TITLE
Load dice.js via external script

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -15,6 +15,7 @@
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { rollDice };
+    global.rollDice = rollDice;
   } else {
     global.rollDice = rollDice;
   }

--- a/index.html
+++ b/index.html
@@ -643,22 +643,11 @@
         <div id="monster-detail-content"></div>
         <button id="close-monster-detail">닫기</button>
     </div>
+    <script src="dice.js"></script>
     <script>
-(function(global){
-  function rollDice(notation){
-    if(typeof notation!=="string") throw new Error("notation must be a string");
-    const m=notation.trim().match(/^(\d*)d(\d+)([+-]\d+)?$/i);
-    if(!m) throw new Error("invalid dice notation");
-    const c=parseInt(m[1]||"1",10);
-    const s=parseInt(m[2],10);
-    const mod=m[3]?parseInt(m[3],10):0;
-    let t=0;
-    for(let i=0;i<c;i++){t+=Math.floor(Math.random()*s)+1;}
-    t+=mod;
-    return t;
-  }
-  global.rollDice=rollDice;
-})(this);
+        if (typeof window.rollDice === "undefined" && typeof require === "function") {
+            window.rollDice = require("./dice.js").rollDice;
+        }
     </script>
     <script>
         const ITEM_TYPES = {

--- a/tests/champion.test.js
+++ b/tests/champion.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/clickMovement.test.js
+++ b/tests/clickMovement.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/healSelf.test.js
+++ b/tests/healSelf.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/homingProjectile.test.js
+++ b/tests/homingProjectile.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/jobSkills.test.js
+++ b/tests/jobSkills.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/magicProjectile.test.js
+++ b/tests/magicProjectile.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/magicScaling.test.js
+++ b/tests/magicScaling.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/mana.test.js
+++ b/tests/mana.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/mercenaryFollow.test.js
+++ b/tests/mercenaryFollow.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const assert = require('assert');
 const { JSDOM } = require('jsdom');
 const path = require('path');
@@ -6,7 +7,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/mercenaryStars.test.js
+++ b/tests/mercenaryStars.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/messageDetail.test.js
+++ b/tests/messageDetail.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/nova.test.js
+++ b/tests/nova.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -1,3 +1,4 @@
+const { rollDice } = require('../dice');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 
@@ -5,7 +6,8 @@ async function run() {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost'
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
   });
 
   await new Promise(resolve => {


### PR DESCRIPTION
## Summary
- remove the inline dice roller from `index.html`
- load `dice.js` via `<script src>` and provide Node fallback
- expose `rollDice` globally when required by Node
- update tests to preload `rollDice`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684563d3b680832796bc08081da1012e