### PR TITLE
Add job skill coverage for all classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2080,7 +2080,7 @@ function killMonster(monster) {
 
         function selectJob() {
             let choice = null;
-            if (typeof window.prompt === 'function') {
+            if (typeof window.prompt === 'function' && !navigator.userAgent.includes('jsdom')) {
                 try {
                     choice = window.prompt('Choose your class: Warrior, Archer, Healer, FireMage, IceMage');
                 } catch(e) { choice = null; }
@@ -4117,8 +4117,8 @@ function killMonster(monster) {
             updateShopDisplay();
         }
 
-        function startGame() {
-            gameState.player.job = selectJob();
+        function startGame(job) {
+            gameState.player.job = job || selectJob();
             const jobSkills = PLAYER_JOB_SKILLS[gameState.player.job] || [];
             jobSkills.forEach(s => {
                 if (!gameState.player.skills.includes(s)) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/jobSkillsAll.test.js
+++ b/tests/jobSkillsAll.test.js
@@ -1,0 +1,39 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost'
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { startGame, gameState } = win;
+  const PLAYER_JOB_SKILLS = win.eval('PLAYER_JOB_SKILLS');
+
+  for (const [job, skills] of Object.entries(PLAYER_JOB_SKILLS)) {
+    startGame(job);
+    if (gameState.player.job !== job ||
+        gameState.player.assignedSkills[1] !== skills[0] ||
+        gameState.player.assignedSkills[2] !== skills[1]) {
+      console.error(`skills mismatch for ${job}`);
+      process.exit(1);
+    }
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- allow specifying a job when starting the game
- avoid `window.prompt` in jsdom tests
- test that each class receives the proper skill loadout
- run new test through npm scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684563d43d24832786b4f50e40d145e6