### PR TITLE
Fix EXP scroll usage and add test

### DIFF
--- a/index.html
+++ b/index.html
@@ -2614,7 +2614,7 @@ function killMonster(monster) {
                 options.push(`${i + 1}: ${m.name}`);
             });
 
-            if (item.type === ITEM_TYPES.POTION) {
+            if (item.type === ITEM_TYPES.POTION || item.type === ITEM_TYPES.EXP_SCROLL) {
                 const choice = prompt(`${item.name}을(를) 사용할 대상을 선택하세요:\n${options.join('\n')}`);
                 if (choice === null) return;
                 const index = parseInt(choice, 10);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/expScroll.test.js
+++ b/tests/expScroll.test.js
@@ -1,0 +1,46 @@
+const { rollDice } = require('../dice');
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createItem, addToInventory, handleItemClick, gameState } = win;
+
+  const scroll = createItem('smallExpScroll', 0, 0);
+  addToInventory(scroll);
+
+  const beforeExp = gameState.player.exp;
+  win.prompt = () => '0';
+  handleItemClick(scroll);
+
+  if (gameState.player.exp !== beforeExp + scroll.expGain) {
+    console.error('exp not gained from scroll');
+    process.exit(1);
+  }
+  if (gameState.player.inventory.some(i => i.id === scroll.id)) {
+    console.error('scroll not consumed');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- handle EXP scrolls in `handleItemClick`
- add an automated test to ensure EXP scrolls increase experience and are consumed
- run new test in npm script

## Testing
- `npm test` *(fails: Could not load script http://localhost/dice.js)*

------
https://chatgpt.com/codex/tasks/task_e_6845678ea6a483279de1834e9daaa86d