### PR TITLE
Remove job selection, player starts with all skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This project is a lightweight browser-based dungeon crawler. It lets players exp
 
 ## Playing
 
-Open `index.html` in a modern web browser to start the game.
-When the page loads you will be asked to choose a job by clicking one of the emoji options and then pressing the [선택] button. Available jobs are **Warrior**, **Archer**, **Healer**, **Fire Mage** and **Ice Mage**. Each job starts with two unique skills already slotted for you.
+Open `index.html` in a modern web browser to start the game. The player now begins with every available skill already learned, so no class selection is required.
 
 
 ### Controls
@@ -21,7 +20,7 @@ Click the buttons in the *Hire Mercenary* panel to recruit warriors, archers, he
 
 ### Shop and Skill System
 
-Spend collected gold in the shop to purchase items. Bought gear is placed in your inventory and can boost your stats when equipped. Each chosen job automatically grants two starting skills that you can assign to the **Skill1** and **Skill2** slots.
+Spend collected gold in the shop to purchase items. Bought gear is placed in your inventory and can boost your stats when equipped. All skills are unlocked from the start and can be assigned to the **Skill1** and **Skill2** slots.
 
 ### Mercenary Skills
 

--- a/index.html
+++ b/index.html
@@ -1040,13 +1040,7 @@
             WIZARD: ['Fireball', 'Iceball']
         };
 
-        const PLAYER_JOB_SKILLS = {
-            Warrior: ['DoubleStrike', 'ChargeAttack'],
-            Archer: ['DoubleStrike', 'HawkEye'],
-            Healer: ['Heal', 'Purify'],
-            FireMage: ['Fireball', 'FireNova'],
-            IceMage: ['Iceball', 'IceNova']
-        };
+
 
         const HEAL_MANA_COST = 2;
 
@@ -2067,27 +2061,15 @@ function killMonster(monster) {
             }
         }
 
-        function selectJob() {
-            let choice = null;
-            if (typeof window.prompt === 'function' && !navigator.userAgent.includes('jsdom')) {
-                try {
-                    choice = window.prompt('Choose your class: Warrior, Archer, Healer, FireMage, IceMage');
-                } catch(e) { choice = null; }
-            }
-            const options = ['Warrior','Archer','Healer','FireMage','IceMage'];
-            if (!options.includes(choice)) choice = 'Warrior';
-            return choice;
-        }
+
 
         function updateActionButtons() {
             const atk = document.getElementById('attack');
             const rng = document.getElementById('ranged');
             const heal = document.getElementById('heal');
-            const job = gameState.player.job;
-            atk.style.display = (!job || job === 'Warrior' ||
-                    job === 'FireMage' || job === 'IceMage') ? 'inline-block' : 'none';
-            rng.style.display = job === 'Archer' ? 'inline-block' : 'none';
-            heal.style.display = job === 'Healer' ? 'inline-block' : 'none';
+            atk.style.display = 'inline-block';
+            rng.style.display = 'inline-block';
+            heal.style.display = 'inline-block';
         }
 
         // 플레이어 레벨업 체크
@@ -2096,32 +2078,9 @@ function killMonster(monster) {
                 gameState.player.exp -= gameState.player.expNeeded;
                 gameState.player.level += 1;
 
-                switch (gameState.player.job) {
-                    case 'Warrior':
-                        gameState.player.endurance += 3;
-                        gameState.player.strength += 2;
-                        break;
-                    case 'Archer':
-                        gameState.player.endurance += 2;
-                        gameState.player.strength += 2;
-                        gameState.player.agility += 1;
-                        break;
-                    case 'FireMage':
-                    case 'IceMage':
-                        gameState.player.endurance += 1;
-                        gameState.player.intelligence += 2;
-                        gameState.player.focus += 2;
-                        break;
-                    case 'Healer':
-                        gameState.player.endurance += 1;
-                        gameState.player.intelligence += 1;
-                        gameState.player.focus += 3;
-                        break;
-                    default:
-                        gameState.player.endurance += 2;
-                        gameState.player.strength += 1;
-                        gameState.player.agility += 1;
-                }
+                gameState.player.endurance += 2;
+                gameState.player.strength += 1;
+                gameState.player.agility += 1;
 
                 gameState.player.health = getStat(gameState.player, 'maxHealth');
                 gameState.player.mana = getStat(gameState.player, 'maxMana');
@@ -4106,16 +4065,16 @@ function killMonster(monster) {
             updateShopDisplay();
         }
 
-        function startGame(job) {
-            gameState.player.job = job || selectJob();
-            const jobSkills = PLAYER_JOB_SKILLS[gameState.player.job] || [];
-            jobSkills.forEach(s => {
+        function startGame() {
+            gameState.player.job = null;
+            const allSkills = Object.keys(SKILL_DEFS);
+            allSkills.forEach(s => {
                 if (!gameState.player.skills.includes(s)) {
                     gameState.player.skills.push(s);
                 }
             });
-            if (jobSkills[0]) gameState.player.assignedSkills[1] = jobSkills[0];
-            if (jobSkills[1]) gameState.player.assignedSkills[2] = jobSkills[1];
+            if (allSkills[0]) gameState.player.assignedSkills[1] = allSkills[0];
+            if (allSkills[1]) gameState.player.assignedSkills[2] = allSkills[1];
 
             generateDungeon();
             for (let i = 0; i < 5; i++) {
@@ -4165,9 +4124,7 @@ function killMonster(monster) {
             }
             else if (e.key.toLowerCase() === 'f' || e.key.toLowerCase() === 'z') {
                 e.preventDefault();
-                if (gameState.player.job === 'Archer') rangedAction();
-                else if (gameState.player.job === 'Healer') healAction();
-                else meleeAttackAction();
+                meleeAttackAction();
             }
             else if (e.key.toLowerCase() === 'x') {
                 e.preventDefault();

--- a/tests/jobSkills.test.js
+++ b/tests/jobSkills.test.js
@@ -24,14 +24,16 @@ async function run() {
   dom.window.requestAnimationFrame = fn => fn();
 
   const { gameState } = dom.window;
+  const SKILL_DEFS = dom.window.eval('SKILL_DEFS');
 
-  if (gameState.player.job !== 'Warrior') {
-    console.error('default job not Warrior');
+  const keys = Object.keys(SKILL_DEFS);
+  if (gameState.player.skills.length !== keys.length || !keys.every(k => gameState.player.skills.includes(k))) {
+    console.error('player does not start with all skills');
     process.exit(1);
   }
 
-  if (gameState.player.assignedSkills[1] !== 'DoubleStrike' || gameState.player.assignedSkills[2] !== 'ChargeAttack') {
-    console.error('job skills not assigned');
+  if (gameState.player.assignedSkills[1] !== keys[0] || gameState.player.assignedSkills[2] !== keys[1]) {
+    console.error('default skill slots not assigned');
     process.exit(1);
   }
 }

--- a/tests/jobSkillsAll.test.js
+++ b/tests/jobSkillsAll.test.js
@@ -23,16 +23,17 @@ async function run() {
   win.requestAnimationFrame = fn => fn();
 
   const { startGame, gameState } = win;
-  const PLAYER_JOB_SKILLS = win.eval('PLAYER_JOB_SKILLS');
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+  const keys = Object.keys(SKILL_DEFS);
 
-  for (const [job, skills] of Object.entries(PLAYER_JOB_SKILLS)) {
-    startGame(job);
-    if (gameState.player.job !== job ||
-        gameState.player.assignedSkills[1] !== skills[0] ||
-        gameState.player.assignedSkills[2] !== skills[1]) {
-      console.error(`skills mismatch for ${job}`);
-      process.exit(1);
-    }
+  startGame();
+  if (gameState.player.skills.length !== keys.length || !keys.every(k => gameState.player.skills.includes(k))) {
+    console.error('startGame did not grant all skills');
+    process.exit(1);
+  }
+  if (gameState.player.assignedSkills[1] !== keys[0] || gameState.player.assignedSkills[2] !== keys[1]) {
+    console.error('skill slots not assigned correctly');
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove job selection logic
- start the game with all skills learned and slots pre-filled
- always show action buttons
- update README to reflect removal of classes
- update tests for new skill defaults

## Testing
- `npm test` *(fails: Could not load script dice.js)*

------
https://chatgpt.com/codex/tasks/task_e_68456e8760bc8327a2be74895d5b7a17