### PR TITLE
Add aura skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1019,7 +1019,9 @@
             Purify: { name: 'Purify', icon: '🌀', purify: true, range: 2, manaCost: 2 },
             DoubleStrike: { name: 'Double Strike', icon: '🔪', range: 1, manaCost: 3, melee: true, hits: 2 },
             ChargeAttack: { name: 'Charge Attack', icon: '⚡', range: 2, manaCost: 2, melee: true, multiplier: 1.5 },
-            HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2, damageDice: '1d6' }
+            HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2, damageDice: '1d6' },
+            MightAura: { name: 'Might Aura', icon: '💪', passive: true, radius: 6, aura: { attack: 1, magicPower: 1 } },
+            ProtectAura: { name: 'Protect Aura', icon: '🛡️', passive: true, radius: 6, aura: { defense: 1, magicResist: 1 } }
         };
 
         // 용병 전용 스킬 정의
@@ -1268,6 +1270,21 @@
             return value;
         }
 
+        function getAuraBonus(character, stat) {
+            let bonus = 0;
+            ['1', '2'].forEach(slot => {
+                const key = gameState.player.assignedSkills[slot];
+                const skill = SKILL_DEFS[key];
+                if (skill && skill.passive && skill.aura && skill.aura[stat] !== undefined) {
+                    const dist = getDistance(gameState.player.x, gameState.player.y, character.x, character.y);
+                    if (dist <= (skill.radius || 0)) {
+                        bonus += skill.aura[stat];
+                    }
+                }
+            });
+            return bonus;
+        }
+
         // 통합 공격 처리
         function performAttack(attacker, defender, options = {}) {
             const magic = options.magic || false;
@@ -1415,6 +1432,7 @@
                     }
                 });
             }
+            value += getAuraBonus(character, stat);
             return value;
         }
 
@@ -3862,6 +3880,11 @@ function killMonster(monster) {
                 return;
             }
             const skill = SKILL_DEFS[skillKey];
+            if (skill.passive) {
+                addMessage('이 스킬은 항상 효과가 발동중입니다.', 'info');
+                processTurn();
+                return;
+            }
             if (gameState.player.mana < skill.manaCost) {
                 addMessage('마나가 부족합니다.', 'info');
                 processTurn();

--- a/tests/aura.test.js
+++ b/tests/aura.test.js
@@ -1,0 +1,72 @@
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const { rollDice } = require('../dice');
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, createMercenary, assignSkill, getStat } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  const size = 5;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.dungeon[1][1] = 'empty';
+
+  const merc = createMercenary('WARRIOR', 2, 1);
+  gameState.activeMercenaries.push(merc);
+
+  assignSkill(1, null);
+  assignSkill(2, null);
+
+  const baseAtk = getStat(merc, 'attack');
+  const baseMag = getStat(merc, 'magicPower');
+  const baseDef = getStat(merc, 'defense');
+  const baseRes = getStat(merc, 'magicResist');
+
+  assignSkill(1, 'MightAura');
+  const bonusAtk = SKILL_DEFS['MightAura'].aura.attack;
+  const bonusMag = SKILL_DEFS['MightAura'].aura.magicPower;
+  if (getStat(merc, 'attack') !== baseAtk + bonusAtk || getStat(merc, 'magicPower') !== baseMag + bonusMag) {
+    console.error('Might Aura not applied');
+    process.exit(1);
+  }
+
+  assignSkill(1, null);
+  if (getStat(merc, 'attack') !== baseAtk || getStat(merc, 'magicPower') !== baseMag) {
+    console.error('Might Aura persisted after unassign');
+    process.exit(1);
+  }
+
+  assignSkill(2, 'ProtectAura');
+  const bonusDef = SKILL_DEFS['ProtectAura'].aura.defense;
+  const bonusRes = SKILL_DEFS['ProtectAura'].aura.magicResist;
+  if (getStat(merc, 'defense') !== baseDef + bonusDef || getStat(merc, 'magicResist') !== baseRes + bonusRes) {
+    console.error('Protect Aura not applied');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add Might Aura and Protect Aura skills
- compute aura bonuses via `getAuraBonus`
- display aura benefits in stat calculations
- ignore passive skills when used
- test aura skill effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684579b5ce348327a823891723dc2242