### PR TITLE
Add mercenary skill leveling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,10 +1209,10 @@
         }
 
         // 간단한 치유 로직
-        function healTarget(healer, target, skillInfo) {
-            const base = skillInfo?.heal ?? 3 + healer.level;
+        function healTarget(healer, target, skillInfo, level = 1) {
+            const base = skillInfo?.heal ?? (3 + healer.level);
             const power = getStat(healer, 'magicPower');
-            let healAmount = Math.min(base + power, getStat(target, 'maxHealth') - target.health);
+            let healAmount = Math.min((base + power) * level, getStat(target, 'maxHealth') - target.health);
             if (healAmount > 0) {
                 target.health += healAmount;
                 const name = target === gameState.player ? '플레이어' : target.name;
@@ -1697,10 +1697,13 @@
             const acc2Btn = merc.equipped && merc.equipped.accessory2
                 ? `<button class="sell-button" onclick="unequipItemFromMercenary('${merc.id}','accessory2')">해제</button>`
                 : '';
-            const skillInfo = MERCENARY_SKILLS[merc.skill];
-            const skillInfo2 = MERCENARY_SKILLS[merc.skill2];
-            let skillText = skillInfo ? `${skillInfo.name} (MP ${skillInfo.manaCost})` : '없음';
-            if (skillInfo2) skillText += ` / ${skillInfo2.name} (MP ${skillInfo2.manaCost})`;
+            const skills = [merc.skill, merc.skill2].filter(Boolean);
+            const skillHtml = skills.map(key => {
+                const info = MERCENARY_SKILLS[key];
+                const lvl = merc.skillLevels && merc.skillLevels[key] || 1;
+                const cost = info.manaCost + lvl - 1;
+                return `<div>${info.icon} ${info.name} Lv.${lvl} (MP ${cost}) <button onclick="upgradeMercenarySkill(window.currentDetailMercenary,'${key}')">레벨업</button></div>`;
+            }).join('');
 
             const html = `
                 <h3>${merc.icon} ${merc.name} Lv.${merc.level}</h3>
@@ -1721,12 +1724,13 @@
                 <div>✨ 마법방어: ${getStat(merc, 'magicResist')}</div>
                 <div>❤️‍🩹 회복력: ${getStat(merc, 'healthRegen')}</div>
                 <div>🔁 마나회복: ${getStat(merc, 'manaRegen')}</div>
+                <div>📚 스킬포인트: ${merc.skillPoints}</div>
                 <hr>
                 <div>무기: ${weapon} ${weaponBtn}</div>
                 <div>방어구: ${armor} ${armorBtn}</div>
                 <div>악세1: ${accessory1} ${acc1Btn}</div>
                 <div>악세2: ${accessory2} ${acc2Btn}</div>
-                <div>스킬: ${skillText}</div>
+                ${skillHtml || '<div>스킬: 없음</div>'}
             `;
 
             document.getElementById('mercenary-detail-content').innerHTML = html;
@@ -1739,6 +1743,25 @@
             document.getElementById('mercenary-detail-panel').style.display = 'none';
             gameState.gameRunning = true;
             window.currentDetailMercenary = null;
+        }
+
+        function upgradeMercenarySkill(merc, key) {
+            const level = merc.skillLevels[key] || 1;
+            const baseCost = 50;
+            const cost = baseCost * level * level;
+            if (merc.skillPoints <= 0) {
+                addMessage('❌ 스킬포인트가 부족합니다.', 'mercenary');
+                return;
+            }
+            if (gameState.player.gold < cost) {
+                addMessage(`💸 골드가 부족합니다. 업그레이드에는 ${formatNumber(cost)} 골드가 필요합니다.`, 'info');
+                return;
+            }
+            merc.skillPoints -= 1;
+            gameState.player.gold -= cost;
+            merc.skillLevels[key] = level + 1;
+            updateStats();
+            showMercenaryDetails(merc);
         }
 
         function showMonsterDetails(monster) {
@@ -2128,6 +2151,7 @@ function killMonster(monster) {
             while (mercenary.exp >= mercenary.expNeeded) {
                 mercenary.exp -= mercenary.expNeeded;
                 mercenary.level += 1;
+                mercenary.skillPoints += 1;
                 mercenary.endurance += 2 + mercenary.stars.endurance * 0.5;
                 mercenary.strength += 1 + mercenary.stars.strength * 0.5;
                 mercenary.agility += 1 + mercenary.stars.agility * 0.5;
@@ -2436,6 +2460,13 @@ function killMonster(monster) {
                 bleedTurns: 0,
                 exp: 0,
                 expNeeded: 15,
+                skillPoints: 0,
+                skillLevels: (() => {
+                    const obj = {};
+                    if (assignedSkill) obj[assignedSkill] = 1;
+                    if (assignedSkill2) obj[assignedSkill2] = 1;
+                    return obj;
+                })(),
                 alive: true,
                 hasActed: false,
                 equipped: {
@@ -3321,6 +3352,8 @@ function killMonster(monster) {
             const minDistanceFromPlayer = 1;
             const maxDistanceFromPlayer = 3;
             const skillInfo = MERCENARY_SKILLS[mercenary.skill];
+            const skillLevel = mercenary.skillLevels && mercenary.skillLevels[mercenary.skill] || 1;
+            const skillManaCost = skillInfo ? skillInfo.manaCost + skillLevel - 1 : 0;
             const baseAttackRange = mercenary.role === 'ranged' ? 3 :
                                    mercenary.role === 'caster' ? 2 : 1;
             let attackRange = baseAttackRange;
@@ -3328,13 +3361,14 @@ function killMonster(monster) {
             // 힐러는 치료 우선
             if (mercenary.role === 'support') {
                 const knowsHeal = skillInfo && mercenary.skill === 'Heal';
-                const manaCost = knowsHeal ? skillInfo.manaCost : HEAL_MANA_COST;
+                const manaCost = knowsHeal ? skillManaCost : HEAL_MANA_COST;
+                const healLevel = knowsHeal ? skillLevel : 1;
                 const healRange = knowsHeal ? skillInfo.range : 2;
 
                 if (mercenary.mana >= manaCost && gameState.player.health < getStat(gameState.player, 'maxHealth') * 0.7) {
                     if (getDistance(mercenary.x, mercenary.y, gameState.player.x, gameState.player.y) <= healRange) {
                         const healed = knowsHeal
-                            ? healTarget(mercenary, gameState.player, skillInfo)
+                            ? healTarget(mercenary, gameState.player, skillInfo, healLevel)
                             : healTarget(mercenary, gameState.player);
                         if (healed) {
                             mercenary.mana -= manaCost;
@@ -3349,7 +3383,7 @@ function killMonster(monster) {
                     if (otherMerc !== mercenary && otherMerc.alive && otherMerc.health < getStat(otherMerc, 'maxHealth') * 0.5) {
                         if (mercenary.mana >= manaCost && getDistance(mercenary.x, mercenary.y, otherMerc.x, otherMerc.y) <= healRange) {
                             const healed = knowsHeal
-                                ? healTarget(mercenary, otherMerc, skillInfo)
+                                ? healTarget(mercenary, otherMerc, skillInfo, healLevel)
                                 : healTarget(mercenary, otherMerc);
                             if (healed) {
                                 mercenary.mana -= manaCost;
@@ -3363,7 +3397,7 @@ function killMonster(monster) {
 
                 if (mercenary.health < getStat(mercenary, 'maxHealth') * 0.5 && mercenary.mana >= manaCost) {
                     const healed = knowsHeal
-                        ? healTarget(mercenary, mercenary, skillInfo)
+                        ? healTarget(mercenary, mercenary, skillInfo, healLevel)
                         : healTarget(mercenary, mercenary);
                     if (healed) {
                         mercenary.mana -= manaCost;
@@ -3374,13 +3408,15 @@ function killMonster(monster) {
                 }
 
                 const purifyInfo = MERCENARY_SKILLS[mercenary.skill2];
-                if (purifyInfo && mercenary.skill2 === 'Purify' && mercenary.mana >= purifyInfo.manaCost) {
+                const purifyLevel = mercenary.skillLevels && mercenary.skillLevels[mercenary.skill2] || 1;
+                const purifyMana = purifyInfo ? purifyInfo.manaCost + purifyLevel - 1 : 0;
+                if (purifyInfo && mercenary.skill2 === 'Purify' && mercenary.mana >= purifyMana) {
                     const inRange = target => getDistance(mercenary.x, mercenary.y, target.x, target.y) <= purifyInfo.range;
                     const hasStatus = t => t.poison || t.burn || t.freeze || t.bleed;
 
                     if (hasStatus(gameState.player) && inRange(gameState.player)) {
                         if (purifyTarget(mercenary, gameState.player, purifyInfo)) {
-                            mercenary.mana -= purifyInfo.manaCost;
+                            mercenary.mana -= purifyMana;
                             updateMercenaryDisplay();
                             mercenary.hasActed = true;
                             return;
@@ -3390,7 +3426,7 @@ function killMonster(monster) {
                     for (const m of gameState.activeMercenaries) {
                         if (m !== mercenary && m.alive && hasStatus(m) && inRange(m)) {
                             if (purifyTarget(mercenary, m, purifyInfo)) {
-                                mercenary.mana -= purifyInfo.manaCost;
+                                mercenary.mana -= purifyMana;
                                 updateMercenaryDisplay();
                                 mercenary.hasActed = true;
                                 return;
@@ -3400,7 +3436,7 @@ function killMonster(monster) {
 
                     if (hasStatus(mercenary)) {
                         if (purifyTarget(mercenary, mercenary, purifyInfo)) {
-                            mercenary.mana -= purifyInfo.manaCost;
+                            mercenary.mana -= purifyMana;
                             updateMercenaryDisplay();
                             mercenary.hasActed = true;
                             return;
@@ -3431,7 +3467,7 @@ function killMonster(monster) {
             if (skillKey === 'HawkEye' && nearestMonster && nearestDistance > attackRange && nearestDistance <= skillInfo.range) {
                 forceSkill = true;
             }
-            if (skillInfo && mercenary.mana >= skillInfo.manaCost && (forceSkill || Math.random() < 0.5)) {
+            if (skillInfo && mercenary.mana >= skillManaCost && (forceSkill || Math.random() < 0.5)) {
                 if (skillKey === 'Heal') {
                     let target = null;
                     if (gameState.player.health < getStat(gameState.player, 'maxHealth') && getDistance(mercenary.x, mercenary.y, gameState.player.x, gameState.player.y) <= skillInfo.range) {
@@ -3448,15 +3484,15 @@ function killMonster(monster) {
                     if (!target && mercenary.health < getStat(mercenary, 'maxHealth')) {
                         target = mercenary;
                     }
-                    if (target && healTarget(mercenary, target, skillInfo)) {
-                        mercenary.mana -= skillInfo.manaCost;
+                    if (target && healTarget(mercenary, target, skillInfo, skillLevel)) {
+                        mercenary.mana -= skillManaCost;
                         updateMercenaryDisplay();
                         mercenary.hasActed = true;
                         return;
                     }
                 } else if (skillKey === 'ChargeAttack' && nearestMonster && nearestDistance <= skillInfo.dashRange && hasLineOfSight(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y)) {
                     let attackValue = getStat(mercenary, 'attack');
-                    attackValue = Math.floor(attackValue * skillInfo.multiplier);
+                    attackValue = Math.floor(attackValue * skillInfo.multiplier * skillLevel);
 
                     const path = findPath(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y);
                     let destX = mercenary.x;
@@ -3544,16 +3580,20 @@ function killMonster(monster) {
                             gameState.monsters.splice(monsterIndex, 1);
                         }
                     }
-                    mercenary.mana -= skillInfo.manaCost;
+                    mercenary.mana -= skillManaCost;
                     updateMercenaryDisplay();
                     mercenary.hasActed = true;
                     return;
                 } else if (nearestMonster && nearestDistance <= skillInfo.range && hasLineOfSight(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y)) {
                     let attackValue = getStat(mercenary, 'attack');
                     if (skillKey === 'ChargeAttack') {
-                        attackValue = Math.floor(attackValue * skillInfo.multiplier);
+                        attackValue = Math.floor(attackValue * skillInfo.multiplier * skillLevel);
                     } else if (skillKey === 'Fireball' || skillKey === 'Iceball') {
-                        attackValue = rollDice(skillInfo.damageDice) + getStat(mercenary, 'magicPower');
+                        attackValue = rollDice(skillInfo.damageDice) * skillLevel + getStat(mercenary, 'magicPower');
+                    } else if (skillKey === 'HawkEye') {
+                        attackValue = rollDice(skillInfo.damageDice) * skillLevel + getStat(mercenary, 'attack');
+                    } else {
+                        attackValue = Math.floor(attackValue * skillLevel);
                     }
 
                     const hits = skillKey === 'DoubleStrike' ? 2 : 1;
@@ -3621,7 +3661,7 @@ function killMonster(monster) {
                             gameState.monsters.splice(monsterIndex, 1);
                         }
                     }
-                    mercenary.mana -= skillInfo.manaCost;
+                    mercenary.mana -= skillManaCost;
                     updateMercenaryDisplay();
                     mercenary.hasActed = true;
                     return;
@@ -3819,6 +3859,14 @@ function killMonster(monster) {
                 }
                 if (!m.stars) {
                     m.stars = generateStars();
+                }
+                if (m.skillPoints === undefined) {
+                    m.skillPoints = 0;
+                }
+                if (!m.skillLevels) {
+                    m.skillLevels = {};
+                    if (m.skill) m.skillLevels[m.skill] = 1;
+                    if (m.skill2) m.skillLevels[m.skill2] = 1;
                 }
             };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -1,0 +1,88 @@
+const { rollDice } = require('../dice');
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    hireMercenary,
+    checkMercenaryLevelUp,
+    upgradeMercenarySkill,
+    processMercenaryTurn,
+    gameState,
+    getStat
+  } = win;
+  const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
+
+  // create basic dungeon
+  const size = 5;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.dungeon[1][1] = 'empty';
+
+  hireMercenary('HEALER');
+  const merc = gameState.activeMercenaries[0];
+  const skillKey = merc.skill;
+
+  // level up check gives skill point
+  merc.exp = merc.expNeeded;
+  const beforePoints = merc.skillPoints;
+  checkMercenaryLevelUp(merc);
+  assert.strictEqual(merc.skillPoints, beforePoints + 1, 'skill points not gained on level up');
+
+  // upgrade skill
+  gameState.player.gold = 1000;
+  merc.skillPoints = 1;
+  const beforeGold = gameState.player.gold;
+  const beforeLevel = merc.skillLevels[skillKey];
+  const cost = 50 * beforeLevel * beforeLevel;
+  upgradeMercenarySkill(merc, skillKey);
+  assert.strictEqual(gameState.player.gold, beforeGold - cost, 'gold not deducted');
+  assert.strictEqual(merc.skillLevels[skillKey], beforeLevel + 1, 'skill level not increased');
+  assert.strictEqual(merc.skillPoints, 0, 'skill points not spent');
+
+  // skill scaling
+  merc.mana = merc.maxMana = 10;
+  merc.health = getStat(merc, 'maxHealth') - 4;
+  const healLevel = merc.skillLevels[skillKey];
+  const manaBefore = merc.mana;
+  const healthBefore = merc.health;
+  const origRandom = win.Math.random;
+  win.Math.random = () => 0;
+  processMercenaryTurn(merc);
+  win.Math.random = origRandom;
+  const startMana = Math.min(manaBefore + getStat(merc, 'manaRegen'), getStat(merc, 'maxMana'));
+  const manaExpected = startMana - (MERCENARY_SKILLS[skillKey].manaCost + healLevel - 1);
+  assert.strictEqual(merc.mana, manaExpected, 'mana cost not scaled with level');
+  const base = 3 + merc.level;
+  const power = getStat(merc, 'magicPower');
+  const healExpected = Math.min((base + power) * healLevel, getStat(merc, 'maxHealth') - healthBefore);
+  assert.strictEqual(merc.health, healthBefore + healExpected, 'heal amount not scaled with level');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- give mercenaries skill points and skill level tracking
- award skill points on mercenary level up
- persist skill info in save data and upgrade older saves
- display skill levels with upgrade buttons and implement upgrading
- scale mercenary skills by level and include mana costs
- test mercenary skill upgrades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845851319948327bfabfe36181dc663