### PR TITLE
Add monster experience gain

### DIFF
--- a/index.html
+++ b/index.html
@@ -1778,6 +1778,7 @@
             document.getElementById('monster-detail-content').innerHTML = html;
             document.getElementById('monster-detail-panel').style.display = 'block';
             gameState.gameRunning = false;
+            window.currentDetailMonster = monster;
         }
 
         function showChampionDetails(champion) {
@@ -1810,6 +1811,7 @@
         function hideMonsterDetails() {
             document.getElementById('monster-detail-panel').style.display = 'none';
             gameState.gameRunning = true;
+            window.currentDetailMonster = null;
         }
 
         function spawnMercenaryNearPlayer(mercenary) {
@@ -1939,6 +1941,7 @@
                 freezeTurns: 0,
                 bleedTurns: 0,
                 exp: data.baseExp,
+                expNeeded: 15,
                 gold: data.baseGold,
                 range: data.range,
                 special: data.special,
@@ -1973,6 +1976,7 @@
                 monster.health = monster.maxHealth;
                 monster.maxMana = getStat(monster, 'maxMana');
                 monster.mana = monster.maxMana;
+                monster.expNeeded = Math.floor((monster.expNeeded || 15) * 1.5);
             }
         }
 
@@ -2266,6 +2270,25 @@ function killMonster(monster) {
                 updateMercenaryDisplay();
                 if (window.currentDetailMercenary && window.currentDetailMercenary.id === mercenary.id) {
                     showMercenaryDetails(mercenary);
+                }
+            }
+        }
+
+        function checkMonsterLevelUp(monster) {
+            while (monster.exp >= monster.expNeeded) {
+                monster.exp -= monster.expNeeded;
+                monster.level += 1;
+                monster.endurance += 2;
+                monster.strength += 1;
+                monster.agility += 1;
+                monster.focus += 1;
+                monster.intelligence += 1;
+                monster.health = getStat(monster, 'maxHealth');
+                monster.mana = getStat(monster, 'maxMana');
+                monster.expNeeded = Math.floor(monster.expNeeded * 1.5);
+                addMessage(`📈 ${monster.name}의 레벨이 ${monster.level}이(가) 되었습니다!`, 'combat');
+                if (window.currentDetailMonster && window.currentDetailMonster.id === monster.id) {
+                    showMonsterDetails(monster);
                 }
             }
         }
@@ -3013,12 +3036,22 @@ function killMonster(monster) {
                 
                 if (nearestTarget.health <= 0) {
                     if (nearestTarget === gameState.player) {
+                        monster.exp += gameState.player.level * 10;
+                        checkMonsterLevelUp(monster);
+                        if (window.currentDetailMonster && window.currentDetailMonster.id === monster.id) {
+                            showMonsterDetails(monster);
+                        }
                         handlePlayerDeath();
                         return true;
                     } else {
                         nearestTarget.alive = false;
                         nearestTarget.health = 0;
                         addMessage(`💀 ${nearestTarget.name}이(가) 전사했습니다...`, "mercenary");
+                        monster.exp += nearestTarget.level * 10;
+                        checkMonsterLevelUp(monster);
+                        if (window.currentDetailMonster && window.currentDetailMonster.id === monster.id) {
+                            showMonsterDetails(monster);
+                        }
                         updateMercenaryDisplay();
                     }
                 }

--- a/tests/monsterExp.test.js
+++ b/tests/monsterExp.test.js
@@ -1,0 +1,58 @@
+const { rollDice } = require('../dice');
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function run() {
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) { window.rollDice = rollDice; }
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  const win = dom.window;
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createMonster, hireMercenary, monsterAttack, gameState } = win;
+
+  const size = 5;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 2;
+  gameState.player.y = 2;
+
+  gameState.player.gold = 1000;
+  hireMercenary('WARRIOR');
+  const merc = gameState.activeMercenaries[0];
+  merc.x = 3;
+  merc.y = 2;
+  merc.health = 1;
+  merc.level = 2;
+
+  const monster = createMonster('GOBLIN', 4, 2, 1);
+  gameState.monsters = [monster];
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  const origRandom = win.Math.random;
+  win.Math.random = () => 0; // ensure hit
+  monsterAttack(monster);
+  win.Math.random = origRandom;
+
+  if (monster.level < 2) {
+    console.error('monster did not gain experience from kill');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- track monster exp thresholds
- update monster detail panel references
- level monsters when they defeat mercenaries or the player
- test monster experience gain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684597877f688327a8012d656e8c1287