### PR TITLE
Refactor tests to preload game functions

### DIFF
--- a/tests/aura.test.js
+++ b/tests/aura.test.js
@@ -1,21 +1,7 @@
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const { rollDice } = require('../dice');
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/champion.test.js
+++ b/tests/champion.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/clickMovement.test.js
+++ b/tests/clickMovement.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/expScroll.test.js
+++ b/tests/expScroll.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/healSelf.test.js
+++ b/tests/healSelf.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,25 @@
+const { rollDice } = require('../dice');
+const { JSDOM } = require('jsdom');
+const path = require('path');
+
+async function loadGame(options = {}) {
+  const { confirmReturn = true } = options;
+  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) {
+      window.rollDice = rollDice;
+      window.confirm = () => confirmReturn;
+    }
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', resolve);
+  });
+
+  return dom.window;
+}
+
+module.exports = { loadGame };

--- a/tests/homingProjectile.test.js
+++ b/tests/homingProjectile.test.js
@@ -1,29 +1,16 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
 
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  dom.window.updateStats = () => {};
-  dom.window.updateMercenaryDisplay = () => {};
-  dom.window.updateInventoryDisplay = () => {};
-  dom.window.renderDungeon = () => {};
-  dom.window.updateCamera = () => {};
-  dom.window.updateSkillDisplay = () => {};
-  dom.window.requestAnimationFrame = fn => fn();
-
-  const { gameState, createMonster, createHomingProjectile, processProjectiles, getDistance } = dom.window;
+  const { gameState, createMonster, createHomingProjectile, processProjectiles, getDistance } = win;
 
   const monster = createMonster('ZOMBIE', gameState.player.x + 3, gameState.player.y);
   gameState.monsters.push(monster);

--- a/tests/jobSkills.test.js
+++ b/tests/jobSkills.test.js
@@ -1,30 +1,17 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
 
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  dom.window.updateStats = () => {};
-  dom.window.updateMercenaryDisplay = () => {};
-  dom.window.updateInventoryDisplay = () => {};
-  dom.window.renderDungeon = () => {};
-  dom.window.updateCamera = () => {};
-  dom.window.updateSkillDisplay = () => {};
-  dom.window.requestAnimationFrame = fn => fn();
-
-  const { gameState } = dom.window;
-  const SKILL_DEFS = dom.window.eval('SKILL_DEFS');
+  const { gameState } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
 
   const keys = Object.keys(SKILL_DEFS);
   if (gameState.player.skills.length !== keys.length || !keys.every(k => gameState.player.skills.includes(k))) {

--- a/tests/jobSkillsAll.test.js
+++ b/tests/jobSkillsAll.test.js
@@ -1,19 +1,7 @@
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost'
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/magicProjectile.test.js
+++ b/tests/magicProjectile.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/magicScaling.test.js
+++ b/tests/magicScaling.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/mana.test.js
+++ b/tests/mana.test.js
@@ -1,29 +1,16 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
 
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  dom.window.updateStats = () => {};
-  dom.window.updateMercenaryDisplay = () => {};
-  dom.window.updateInventoryDisplay = () => {};
-  dom.window.renderDungeon = () => {};
-  dom.window.updateCamera = () => {};
-  dom.window.updateSkillDisplay = () => {};
-  dom.window.requestAnimationFrame = fn => fn();
-
-  const { gameState, assignSkill, skill1Action, movePlayer, createMonster } = dom.window;
+  const { gameState, assignSkill, skill1Action, movePlayer, createMonster } = win;
 
   gameState.player.skills.push('Fireball');
   assignSkill(1, 'Fireball');

--- a/tests/mercenaryFollow.test.js
+++ b/tests/mercenaryFollow.test.js
@@ -1,29 +1,17 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
+  const win = await loadGame();
 
   // override visual methods
-  dom.window.updateStats = () => {};
-  dom.window.updateMercenaryDisplay = () => {};
-  dom.window.updateInventoryDisplay = () => {};
-  dom.window.renderDungeon = () => {};
-  dom.window.updateCamera = () => {};
-  dom.window.requestAnimationFrame = fn => fn();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
 
-  const { hireMercenary, movePlayer, saveGame, localStorage, gameState } = dom.window;
+  const { hireMercenary, movePlayer, saveGame, localStorage, gameState } = win;
 
   // ensure enough gold for hiring
   gameState.player.gold = 200;

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -1,38 +1,26 @@
-const { rollDice } = require('../dice');
+const { loadGame } = require('./helpers');
 const assert = require('assert');
-const { JSDOM } = require('jsdom');
-const path = require('path');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
+  const win = await loadGame();
 
   // stub out visual functions
-  dom.window.updateStats = () => {};
-  dom.window.updateMercenaryDisplay = () => {};
-  dom.window.updateInventoryDisplay = () => {};
-  dom.window.renderDungeon = () => {};
-  dom.window.updateCamera = () => {};
-  dom.window.updateSkillDisplay = () => {};
-  dom.window.requestAnimationFrame = fn => fn();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
 
   const {
     hireMercenary,
     createMonster,
     processMercenaryTurn,
     gameState
-  } = dom.window;
+  } = win;
 
-  const MERCENARY_SKILLS = dom.window.eval('MERCENARY_SKILLS');
+  const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
 
   // create a simple empty dungeon
   const size = 5;

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -1,22 +1,8 @@
-const { rollDice } = require('../dice');
+const { loadGame } = require('./helpers');
 const assert = require('assert');
-const { JSDOM } = require('jsdom');
-const path = require('path');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/mercenaryStars.test.js
+++ b/tests/mercenaryStars.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/messageDetail.test.js
+++ b/tests/messageDetail.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/nova.test.js
+++ b/tests/nova.test.js
@@ -1,21 +1,7 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
-
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  const win = dom.window;
+  const win = await loadGame();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -1,32 +1,19 @@
-const { rollDice } = require('../dice');
-const { JSDOM } = require('jsdom');
-const path = require('path');
+const { loadGame } = require('./helpers');
 
 async function run() {
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
-    runScripts: 'dangerously',
-    resources: 'usable',
-    url: 'http://localhost',
-    beforeParse(window) { window.rollDice = rollDice; }
-  });
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
 
-  await new Promise(resolve => {
-    if (dom.window.document.readyState === 'complete') resolve();
-    else dom.window.addEventListener('load', resolve);
-  });
-
-  dom.window.updateStats = () => {};
-  dom.window.updateMercenaryDisplay = () => {};
-  dom.window.updateInventoryDisplay = () => {};
-  dom.window.renderDungeon = () => {};
-  dom.window.updateCamera = () => {};
-  dom.window.requestAnimationFrame = fn => fn();
-
-  const { createItem, formatItem, PREFIXES, SUFFIXES } = dom.window;
+  const { createItem, formatItem, PREFIXES, SUFFIXES } = win;
 
   const seq = [0, 0, 0.35, 0, 0.35];
-  const origRandom = dom.window.Math.random;
-  dom.window.Math.random = () => seq.shift() ?? origRandom();
+  const origRandom = win.Math.random;
+  win.Math.random = () => seq.shift() ?? origRandom();
 
   const item = createItem('shortSword', 0, 0);
 


### PR DESCRIPTION
## Summary
- add `tests/helpers.js` helper to load `index.html`
- predefine `window.rollDice` and `window.confirm` in helper
- update all JSDOM-based tests to use the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845978af370832794f76faec82adb60