### PR TITLE
Item drop next to corpses

### DIFF
--- a/index.html
+++ b/index.html
@@ -2002,6 +2002,23 @@ function createTreasure(x, y, gold) {
             return { x, y, gold: gold + floorBonus };
         }
 
+function findAdjacentEmpty(x, y) {
+            const dirs = [
+                {dx:1, dy:0}, {dx:-1, dy:0}, {dx:0, dy:1}, {dx:0, dy:-1},
+                {dx:1, dy:1}, {dx:-1, dy:-1}, {dx:1, dy:-1}, {dx:-1, dy:1}
+            ];
+            for (const d of dirs) {
+                const nx = x + d.dx;
+                const ny = y + d.dy;
+                if (nx >= 0 && nx < gameState.dungeonSize &&
+                    ny >= 0 && ny < gameState.dungeonSize &&
+                    gameState.dungeon[ny][nx] === 'empty') {
+                    return {x:nx, y:ny};
+                }
+            }
+            return {x, y};
+        }
+
 function killMonster(monster) {
             addMessage(`💀 ${monster.name}을(를) 처치했습니다!`, 'combat');
             gameState.player.exp += monster.exp;
@@ -2013,16 +2030,20 @@ function killMonster(monster) {
                 const eq = Object.values(monster.equipped || {}).filter(i => i);
                 if (eq.length) {
                     const drop = eq[Math.floor(Math.random() * eq.length)];
-                    drop.x = monster.x;
-                    drop.y = monster.y;
+                    const pos = findAdjacentEmpty(monster.x, monster.y);
+                    drop.x = pos.x;
+                    drop.y = pos.y;
                     gameState.items.push(drop);
+                    gameState.dungeon[pos.y][pos.x] = 'item';
                 }
             } else if (monster.special === 'boss') {
                 const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
                 if (Math.random() < 0.2) bossItems.push('reviveScroll');
                 const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                const bossItem = createItem(bossItemKey, monster.x, monster.y);
+                const pos = findAdjacentEmpty(monster.x, monster.y);
+                const bossItem = createItem(bossItemKey, pos.x, pos.y);
                 gameState.items.push(bossItem);
+                gameState.dungeon[pos.y][pos.x] = 'item';
                 addMessage(`🎁 ${monster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, 'treasure');
             } else {
                 let lootChance = monster.lootChance;
@@ -2033,8 +2054,10 @@ function killMonster(monster) {
                     if (Math.random() < 0.1 && ITEMS.reviveScroll.level <= Math.ceil(gameState.floor / 2 + 1)) {
                         randomItemKey = 'reviveScroll';
                     }
-                    const droppedItem = createItem(randomItemKey, monster.x, monster.y);
+                    const pos = findAdjacentEmpty(monster.x, monster.y);
+                    const droppedItem = createItem(randomItemKey, pos.x, pos.y);
                     gameState.items.push(droppedItem);
+                    gameState.dungeon[pos.y][pos.x] = 'item';
                     addMessage(`📦 ${monster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, 'item');
                 }
             }
@@ -3691,9 +3714,10 @@ function killMonster(monster) {
                             const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const bossItem = createItem(bossItemKey, nearestMonster.x, nearestMonster.y);
+                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
+                            const bossItem = createItem(bossItemKey, pos.x, pos.y);
                             gameState.items.push(bossItem);
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            gameState.dungeon[pos.y][pos.x] = 'item';
                             addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
                         } else if (Math.random() < nearestMonster.lootChance) {
                             const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
@@ -3705,9 +3729,10 @@ function killMonster(monster) {
                                 randomItemKey = 'reviveScroll';
                             }
 
-                            const droppedItem = createItem(randomItemKey, nearestMonster.x, nearestMonster.y);
+                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
+                            const droppedItem = createItem(randomItemKey, pos.x, pos.y);
                             gameState.items.push(droppedItem);
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            gameState.dungeon[pos.y][pos.x] = 'item';
                             addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
                         } else {
                             gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
@@ -3772,9 +3797,10 @@ function killMonster(monster) {
                             const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const bossItem = createItem(bossItemKey, nearestMonster.x, nearestMonster.y);
+                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
+                            const bossItem = createItem(bossItemKey, pos.x, pos.y);
                             gameState.items.push(bossItem);
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            gameState.dungeon[pos.y][pos.x] = 'item';
                             addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
                         } else if (Math.random() < nearestMonster.lootChance) {
                             const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
@@ -3786,9 +3812,10 @@ function killMonster(monster) {
                                 randomItemKey = 'reviveScroll';
                             }
 
-                            const droppedItem = createItem(randomItemKey, nearestMonster.x, nearestMonster.y);
+                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
+                            const droppedItem = createItem(randomItemKey, pos.x, pos.y);
                             gameState.items.push(droppedItem);
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            gameState.dungeon[pos.y][pos.x] = 'item';
                             addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
                         } else {
                             gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
@@ -3843,9 +3870,10 @@ function killMonster(monster) {
                             const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
                             if (Math.random() < 0.2) bossItems.push('reviveScroll');
                             const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const bossItem = createItem(bossItemKey, nearestMonster.x, nearestMonster.y);
+                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
+                            const bossItem = createItem(bossItemKey, pos.x, pos.y);
                             gameState.items.push(bossItem);
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            gameState.dungeon[pos.y][pos.x] = 'item';
                             addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
                         } else if (Math.random() < nearestMonster.lootChance) {
                             const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
@@ -3857,9 +3885,10 @@ function killMonster(monster) {
                                 randomItemKey = 'reviveScroll';
                             }
 
-                            const droppedItem = createItem(randomItemKey, nearestMonster.x, nearestMonster.y);
+                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
+                            const droppedItem = createItem(randomItemKey, pos.x, pos.y);
                             gameState.items.push(droppedItem);
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'item';
+                            gameState.dungeon[pos.y][pos.x] = 'item';
                             addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
                         } else {
                             gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/itemDropAdjacent.test.js
+++ b/tests/itemDropAdjacent.test.js
@@ -1,0 +1,52 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createChampion, createItem, killMonster, gameState } = win;
+
+  const champ = createChampion('ARCHER', 1, 1, 1);
+  champ.equipped.weapon = createItem('shortSword', 0, 0);
+
+  gameState.dungeonSize = 3;
+  gameState.dungeon = Array.from({ length: 3 }, () => Array(3).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: 3 }, () => Array(3).fill(false));
+  gameState.monsters = [champ];
+  gameState.items = [];
+  gameState.corpses = [];
+  gameState.dungeon[1][1] = 'monster';
+
+  killMonster(champ);
+
+  if (gameState.items.length !== 1) {
+    console.error('item not dropped');
+    process.exit(1);
+  }
+  const item = gameState.items[0];
+  const dx = Math.abs(item.x - 1);
+  const dy = Math.abs(item.y - 1);
+  if (dx === 0 && dy === 0) {
+    console.error('item dropped on corpse');
+    process.exit(1);
+  }
+  if (dx > 1 || dy > 1) {
+    console.error('item not adjacent');
+    process.exit(1);
+  }
+  if (gameState.dungeon[1][1] !== 'corpse') {
+    console.error('corpse not recorded');
+    process.exit(1);
+  }
+  if (gameState.dungeon[item.y][item.x] !== 'item') {
+    console.error('drop cell not marked item');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -47,12 +47,12 @@ async function run() {
   const skillCost = MERCENARY_SKILLS[merc.skill].manaCost;
   merc.mana = merc.maxMana;
   const initialMana = merc.mana;
-  const origRandom = dom.window.Math.random;
-  dom.window.Math.random = () => 0;
+  const origRandom = win.Math.random;
+  win.Math.random = () => 0;
 
   processMercenaryTurn(merc);
 
-  dom.window.Math.random = origRandom;
+  win.Math.random = origRandom;
 
   const expected = initialMana - skillCost;
   assert.strictEqual(merc.mana, expected, 'mana should decrease by skill cost');

--- a/tests/mercenaryStars.test.js
+++ b/tests/mercenaryStars.test.js
@@ -1,7 +1,7 @@
-const { loadGame } = require('./helpers');
+const { loadGame: loadGameHelper } = require('./helpers');
 
 async function run() {
-  const win = await loadGame();
+  const win = await loadGameHelper();
   win.updateStats = () => {};
   win.updateMercenaryDisplay = () => {};
   win.updateInventoryDisplay = () => {};
@@ -9,7 +9,7 @@ async function run() {
   win.updateCamera = () => {};
   win.requestAnimationFrame = fn => fn();
 
-  const { hireMercenary, gameState, checkMercenaryLevelUp, showMercenaryDetails, saveGame, loadGame, localStorage } = win;
+  const { hireMercenary, gameState, checkMercenaryLevelUp, showMercenaryDetails, saveGame, loadGame: loadGameGame, localStorage } = win;
 
   gameState.player.gold = 500;
   hireMercenary('WARRIOR');
@@ -40,7 +40,7 @@ async function run() {
 
   delete merc.stars;
   saveGame();
-  loadGame();
+  loadGameGame();
   const loaded = gameState.activeMercenaries[0];
   const loadSum = Object.values(loaded.stars).reduce((a,b)=>a+b,0);
   if (loadSum > 9) {

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -17,7 +17,7 @@ async function run() {
 
   const item = createItem('shortSword', 0, 0);
 
-  dom.window.Math.random = origRandom;
+  win.Math.random = origRandom;
 
   if (item.prefix !== 'Refreshing' || item.suffix !== 'of Wisdom') {
     console.error('prefix or suffix not applied');


### PR DESCRIPTION
## Summary
- drop loot next to corpse rather than on the same tile
- add helper to find an empty adjacent cell
- expand test suite with item drop check
- fix tests expecting `dom` object

## Testing
- `npm test` *(fails: monsterExp.test.js: monster did not gain experience from kill)*

------
https://chatgpt.com/codex/tasks/task_e_68459c6792148327b11edf16568aa28c