### PR TITLE
Add elite monsters with aura skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ in the UI.
 
 *This system has been removed.* Mercenaries no longer receive random traits or related bonuses.
 
+### Elite Monsters and Auras
+
+Each dungeon floor now contains at least one **elite** monster. Elites boast higher stats and randomly receive an aura skill that benefits nearby allies. When an elite is revived as a mercenary, it keeps this aura skill. Elites appear with a purple glow and the "엘리트" prefix.
+
 ## Development
 
 Install dependencies with:

--- a/index.html
+++ b/index.html
@@ -101,6 +101,12 @@
             box-shadow: 0 0 8px rgba(255, 152, 0, 0.7);
             animation: monsterPulse 1.5s ease-in-out infinite alternate;
         }
+        .elite {
+            background: radial-gradient(circle, #9C27B0, #7B1FA2);
+            color: white;
+            box-shadow: 0 0 8px rgba(156, 39, 176, 0.7);
+            animation: monsterPulse 1.5s ease-in-out infinite alternate;
+        }
         @keyframes monsterPulse {
             from { transform: scale(1); }
             to { transform: scale(1.1); }
@@ -1037,7 +1043,13 @@
             ChargeAttack: { name: 'Charge Attack', icon: '⚡', range: 2, manaCost: 2, melee: true, multiplier: 1.5 },
             HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2, damageDice: '1d6' },
             MightAura: { name: 'Might Aura', icon: '💪', passive: true, radius: 6, aura: { attack: 1, magicPower: 1 } },
-            ProtectAura: { name: 'Protect Aura', icon: '🛡️', passive: true, radius: 6, aura: { defense: 1, magicResist: 1 } }
+            ProtectAura: { name: 'Protect Aura', icon: '🛡️', passive: true, radius: 6, aura: { defense: 1, magicResist: 1 } },
+            RegenerationAura: { name: 'Regeneration Aura', icon: '💚', passive: true, radius: 6, aura: { healthRegen: 1 } },
+            MeditationAura: { name: 'Meditation Aura', icon: '🌀', passive: true, radius: 6, aura: { manaRegen: 1 } },
+            HasteAura: { name: 'Haste Aura', icon: '💨', passive: true, radius: 6, aura: { evasion: 0.05 } },
+            ConcentrationAura: { name: 'Concentration Aura', icon: '🎯', passive: true, radius: 6, aura: { accuracy: 0.05 } },
+            CondemnAura: { name: 'Condemn Aura', icon: '⚔️', passive: true, radius: 6, aura: { critChance: 0.05 } },
+            NaturalAura: { name: 'Natural Aura', icon: '🌿', passive: true, radius: 6, aura: { defense: 1, magicResist: 1 } }
         };
 
         // 용병 전용 스킬 정의
@@ -1048,7 +1060,13 @@
             Purify: { name: 'Purify', icon: '🌀', range: 2, manaCost: 2 },
             Fireball: { name: 'Fireball', icon: '🔥', range: 4, manaCost: 3, damageDice: '1d8', magic: true, element: 'fire' },
             Iceball: { name: 'Iceball', icon: '❄️', range: 5, manaCost: 2, damageDice: '1d8', magic: true, element: 'ice' },
-            HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2 }
+            HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2 },
+            RegenerationAura: { name: 'Regeneration Aura', icon: '💚', passive: true, radius: 6, aura: { healthRegen: 1 } },
+            MeditationAura: { name: 'Meditation Aura', icon: '🌀', passive: true, radius: 6, aura: { manaRegen: 1 } },
+            HasteAura: { name: 'Haste Aura', icon: '💨', passive: true, radius: 6, aura: { evasion: 0.05 } },
+            ConcentrationAura: { name: 'Concentration Aura', icon: '🎯', passive: true, radius: 6, aura: { accuracy: 0.05 } },
+            CondemnAura: { name: 'Condemn Aura', icon: '⚔️', passive: true, radius: 6, aura: { critChance: 0.05 } },
+            NaturalAura: { name: 'Natural Aura', icon: '🌿', passive: true, radius: 6, aura: { defense: 1, magicResist: 1 } }
         };
 
         const MERCENARY_SKILL_SETS = {
@@ -1300,6 +1318,26 @@
                         bonus += skill.aura[stat];
                     }
                 }
+            });
+
+            gameState.monsters.filter(m => m.isElite).forEach(elite => {
+                const key = elite.auraSkill;
+                const skill = SKILL_DEFS[key];
+                if (skill && skill.passive && skill.aura && skill.aura[stat] !== undefined) {
+                    const dist = getDistance(elite.x, elite.y, character.x, character.y);
+                    if (dist <= (skill.radius || 0)) bonus += skill.aura[stat];
+                }
+            });
+
+            gameState.activeMercenaries.filter(m => m.alive).forEach(merc => {
+                const skills = [merc.skill, merc.skill2, merc.auraSkill];
+                skills.filter(Boolean).forEach(key => {
+                    const skill = SKILL_DEFS[key];
+                    if (skill && skill.passive && skill.aura && skill.aura[stat] !== undefined) {
+                        const dist = getDistance(merc.x, merc.y, character.x, character.y);
+                        if (dist <= (skill.radius || 0)) bonus += skill.aura[stat];
+                    }
+                });
             });
             return bonus;
         }
@@ -1970,6 +2008,21 @@
             return monster;
         }
 
+        function createEliteMonster(type, x, y, level = 1) {
+            const monster = createMonster(type, x, y, level + 1);
+            const auraKeys = ['RegenerationAura', 'MeditationAura', 'HasteAura', 'ConcentrationAura', 'CondemnAura', 'NaturalAura'];
+            const auraSkill = auraKeys[Math.floor(Math.random() * auraKeys.length)];
+            monster.isElite = true;
+            monster.auraSkill = auraSkill;
+            monster.name = `엘리트 ${monster.name}`;
+            monster.attack = Math.floor(monster.attack * 1.5);
+            monster.defense = Math.floor(monster.defense * 1.5);
+            monster.health = Math.floor(monster.health * 1.5);
+            monster.maxHealth = monster.health;
+            monster.lootChance = 0.6;
+            return monster;
+        }
+
         function setMercenaryLevel(mercenary, level) {
             for (let i = 1; i < level; i++) {
                 mercenary.level += 1;
@@ -2091,7 +2144,7 @@ function killMonster(monster) {
                 mana: monster.maxMana,
                 healthRegen: monster.healthRegen || 0,
                 manaRegen: monster.manaRegen || 1,
-                skill: null,
+                skill: monster.isElite ? monster.auraSkill : null,
                 skill2: null,
                 attack: monster.attack,
                 defense: monster.defense,
@@ -2107,7 +2160,7 @@ function killMonster(monster) {
                 exp: 0,
                 expNeeded: 15,
                 skillPoints: 0,
-                skillLevels: {},
+                skillLevels: monster.isElite && monster.auraSkill ? { [monster.auraSkill]: 1 } : {},
                 alive: true,
                 hasActed: false,
                 equipped: { weapon: null, armor: null, accessory1: null, accessory2: null },
@@ -2211,6 +2264,7 @@ function killMonster(monster) {
                                 if (m) {
                                     div.textContent = m.icon;
                                     if (m.isChampion) cellType = 'champion';
+                                    else if (m.isElite) cellType = 'elite';
                                 }
                             } else if (cellType === 'item') {
                                 const it = gameState.items.find(it => it.x === x && it.y === y);
@@ -2414,6 +2468,26 @@ function killMonster(monster) {
                 const champ = createChampion(ct, cx, cy, gameState.floor);
                 gameState.monsters.push(champ);
                 gameState.dungeon[cy][cx] = 'monster';
+            }
+
+            // 층마다 엘리트 몬스터 배치
+            let ex, ey;
+            do {
+                ex = Math.floor(Math.random() * size);
+                ey = Math.floor(Math.random() * size);
+            } while (gameState.dungeon[ey][ex] !== 'empty');
+            const eType = monsterTypes[Math.floor(Math.random() * (monsterTypes.length - 1))];
+            const elite = createEliteMonster(eType, ex, ey, gameState.floor);
+            gameState.monsters.push(elite);
+            gameState.dungeon[ey][ex] = 'monster';
+            const around = 2 + Math.floor(Math.random() * 4);
+            for (let i = 0; i < around; i++) {
+                const pos = findAdjacentEmpty(ex, ey);
+                if (gameState.dungeon[pos.y][pos.x] !== 'empty') continue;
+                const t = monsterTypes[Math.floor(Math.random() * (monsterTypes.length - 1))];
+                const m = createMonster(t, pos.x, pos.y, gameState.floor);
+                gameState.monsters.push(m);
+                gameState.dungeon[pos.y][pos.x] = 'monster';
             }
 
             // 보물은 던전 크기와 층수에 따라 적당히 배치

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js && node tests/elite.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/elite.test.js
+++ b/tests/elite.test.js
@@ -1,0 +1,48 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createEliteMonster, convertMonsterToMercenary, getStat, gameState } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  const origRandom = win.Math.random;
+  win.Math.random = () => 0; // always pick first aura skill
+  const elite = createEliteMonster('GOBLIN', 1, 1, 1);
+  win.Math.random = origRandom;
+
+  if (!elite.isElite || !elite.auraSkill) {
+    console.error('elite not created properly');
+    process.exit(1);
+  }
+
+  gameState.monsters.push(elite);
+  gameState.dungeonSize = 3;
+  gameState.dungeon = Array.from({ length: 3 }, () => Array(3).fill('empty'));
+  gameState.dungeon[1][1] = 'monster';
+  gameState.player.x = 2;
+  gameState.player.y = 1;
+
+  const base = gameState.player.healthRegen;
+  const regen = getStat(gameState.player, 'healthRegen');
+  const auraVal = SKILL_DEFS[elite.auraSkill].aura.healthRegen;
+  if (Math.abs(regen - (base + auraVal)) > 0.001) {
+    console.error('aura bonus not applied');
+    process.exit(1);
+  }
+
+  const merc = convertMonsterToMercenary(elite);
+  if (merc.skill !== elite.auraSkill) {
+    console.error('aura skill not kept on revival');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- create new aura skills and make them available to mercenaries
- add elite monster generation and aura skill inheritance
- spawn elite monsters during dungeon creation
- allow aura bonuses from elites and mercenaries
- mark elite units with special style and prefix
- test elite monster creation and revival

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a85a9534832782ef7842d3adf390