### PR TITLE
Use sorted copy for mercenary turns

### DIFF
--- a/index.html
+++ b/index.html
@@ -3456,18 +3456,18 @@ function killMonster(monster) {
                 mercenary.nextY = mercenary.y;
             });
 
-            gameState.activeMercenaries.sort((a, b) => {
+            const sortedMercenaries = [...gameState.activeMercenaries].sort((a, b) => {
                 const da = getDistance(a.x, a.y, gameState.player.x, gameState.player.y);
                 const db = getDistance(b.x, b.y, gameState.player.x, gameState.player.y);
                 return db - da; // farthest first
             });
 
-            gameState.activeMercenaries.forEach(mercenary => {
+            sortedMercenaries.forEach(mercenary => {
                 processMercenaryTurn(mercenary);
             });
 
             const occupied = new Set();
-            gameState.activeMercenaries.forEach(mercenary => {
+            sortedMercenaries.forEach(mercenary => {
                 const key = `${mercenary.nextX},${mercenary.nextY}`;
                 if (!occupied.has(key)) {
                     mercenary.x = mercenary.nextX;


### PR DESCRIPTION
## Summary
- avoid mutating `gameState.activeMercenaries` order
- process mercenary turns with a sorted copy instead

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b28ca1bc832797ac0fc684e4ff71