### PR TITLE
Update item target UI and add prompt test

### DIFF
--- a/index.html
+++ b/index.html
@@ -4592,6 +4592,12 @@ function killMonster(monster) {
                     addBtn(m.name, () => equipItemToMercenary(item, m));
                 });
             }
+            const buttons = content.querySelectorAll('.target-button');
+            if (buttons.length === 1) {
+                buttons[0].click();
+                return;
+            }
+
             if (typeof prompt === 'function') {
                 const msg = choices.map((c, i) => `${i}: ${c.label}`).join('\n');
                 const res = prompt(msg);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
     "pretest": "npm install",
-    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js && node tests/elite.test.js"
+    "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js && node tests/itemTargetPrompt.test.js && node tests/elite.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/itemTargetPrompt.test.js
+++ b/tests/itemTargetPrompt.test.js
@@ -1,0 +1,31 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { hireMercenary, createItem, addToInventory, handleItemClick, gameState } = win;
+
+  hireMercenary('WARRIOR');
+  const merc = gameState.activeMercenaries[0];
+
+  const scroll = createItem('smallExpScroll', 0, 0);
+  addToInventory(scroll);
+  const beforeExp = merc.exp;
+
+  win.prompt = () => '1';
+  handleItemClick(scroll);
+
+  if (merc.exp !== beforeExp + scroll.expGain) {
+    console.error('prompt target selection failed');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add automatic target selection or prompt-based selection when items are used
- run target prompt tests automatically
- add new itemTargetPrompt.test.js

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845bc84cd9c83278789ee9d6955265d