### PR TITLE
Optimize pathfinding queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1454,14 +1454,15 @@
         function findPath(startX, startY, targetX, targetY) {
             const size = gameState.dungeonSize;
             const queue = [[startX, startY]];
+            let head = 0;
             const visited = Array.from({ length: size }, () => Array(size).fill(false));
             const cameFrom = {};
             const key = (x, y) => `${x},${y}`;
             visited[startY][startX] = true;
             cameFrom[key(startX, startY)] = null;
 
-            while (queue.length) {
-                const [x, y] = queue.shift();
+            while (head < queue.length) {
+                const [x, y] = queue[head++];
                 if (x === targetX && y === targetY) {
                     const path = [];
                     let cur = [x, y];


### PR DESCRIPTION
## Summary
- avoid reallocating the BFS queue by using a `head` index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68465b67984083279ac4b0b9ecbb1504