### PR TITLE
Fix aura skill display for elite monsters

### DIFF
--- a/index.html
+++ b/index.html
@@ -2190,6 +2190,8 @@
         }
 
         function showMonsterDetails(monster) {
+            const auraInfo = monster.isElite && monster.auraSkill ? SKILL_DEFS[monster.auraSkill] : null;
+            const auraLine = auraInfo ? `<div>오라 스킬: ${auraInfo.icon} ${auraInfo.name}</div>` : '';
             const html = `
                 <h3>${monster.icon} ${monster.name} (Lv.${monster.level})</h3>
                 <div>❤️ HP: ${monster.health}/${monster.maxHealth}</div>
@@ -2207,6 +2209,7 @@
                 <div>📖 지능: ${monster.intelligence}${monster.isSuperior ? ' ' + '★'.repeat(monster.stars.intelligence) : ''}</div>
                 <div>📏 사거리: ${monster.range}</div>
                 <div>특수: ${monster.special || '없음'}</div>
+                ${auraLine}
             `;
             document.getElementById('monster-detail-content').innerHTML = html;
             document.getElementById('monster-detail-panel').style.display = 'block';
@@ -2566,6 +2569,7 @@ function killMonster(monster) {
                 mana: monster.maxMana,
                 healthRegen: monster.healthRegen || 0,
                 manaRegen: monster.manaRegen || 1,
+                auraSkill: monster.auraSkill || null,
                 skill: (() => {
                     if (monster.isSuperior) return monster.skill;
                     if (monster.isElite) return monster.auraSkill;


### PR DESCRIPTION
## Summary
- show aura skill in monster detail panel
- preserve aura skills when converting monsters to mercenaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68465d7d9588832796ee64c243bbb27d