### PR TITLE
Fix residual icons when rendering cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -2774,6 +2774,7 @@ function killMonster(monster) {
                 for (let x = 0; x < gameState.dungeonSize; x++) {
                     const div = gameState.cellElements[y][x];
                     let cellType = gameState.dungeon[y][x];
+                    div.textContent = '';
 
                     if (x === gameState.player.x && y === gameState.player.y) {
                         cellType = 'player';


### PR DESCRIPTION
## Summary
- clear `div.textContent` before populating icons in `renderDungeon`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68465fff76508327b6bfcb02f1ca1b53