### PR TITLE
Expand monster skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1276,7 +1276,9 @@
         const MONSTER_SKILLS = {
             RottingBite: { name: 'Rotting Bite', icon: '🧟', range: 1, damageDice: '1d6', melee: true, status: 'poison' },
             PowerStrike: { name: 'Power Strike', icon: '💥', range: 1, damageDice: '1d8', melee: true },
-            ShadowBolt: { name: 'Shadow Bolt', icon: '🌑', range: 3, damageDice: '1d6', magic: true, element: 'dark' }
+            ShadowBolt: { name: 'Shadow Bolt', icon: '🌑', range: 3, damageDice: '1d6', magic: true, element: 'dark' },
+            PoisonCloud: { name: 'Poison Cloud', icon: '☣️', radius: 2, damageDice: '1d4', magic: true, status: 'poison' },
+            FireBreath: { name: 'Fire Breath', icon: '🔥', radius: 2, magic: true, element: 'fire', damageDice: '1d6', status: 'burn' }
         };
 
         const MERCENARY_SKILL_SETS = {
@@ -1287,20 +1289,20 @@
         };
 
         const MONSTER_SKILL_SETS = {
-            ZOMBIE: ['RottingBite'],
+            ZOMBIE: ['RottingBite', 'PoisonCloud'],
             GOBLIN: ['PowerStrike'],
             ARCHER: ['PowerStrike'],
             GOBLIN_ARCHER: ['PowerStrike'],
-            GOBLIN_WIZARD: ['ShadowBolt'],
-            WIZARD: ['ShadowBolt'],
+            GOBLIN_WIZARD: ['ShadowBolt', 'PoisonCloud'],
+            WIZARD: ['ShadowBolt', 'FireBreath'],
             ORC: ['PowerStrike'],
             ORC_ARCHER: ['PowerStrike'],
             SKELETON: ['PowerStrike'],
             SKELETON_MAGE: ['ShadowBolt'],
-            TROLL: ['PowerStrike'],
-            DARK_MAGE: ['ShadowBolt'],
-            DEMON_WARRIOR: ['ShadowBolt'],
-            BOSS: ['ShadowBolt']
+            TROLL: ['PowerStrike', 'FireBreath'],
+            DARK_MAGE: ['ShadowBolt', 'PoisonCloud'],
+            DEMON_WARRIOR: ['ShadowBolt', 'FireBreath'],
+            BOSS: ['ShadowBolt', 'FireBreath']
         };
 
         const RECIPES = {

--- a/tests/monsterSkill.test.js
+++ b/tests/monsterSkill.test.js
@@ -32,31 +32,41 @@ async function run() {
   gameState.corpses = [];
   gameState.items = [];
 
-  const level = 4;
-  const monster = createMonster('ZOMBIE', 1, 1, level);
-  if (!monster.monsterSkill || !MONSTER_SKILL_SETS.ZOMBIE.includes(monster.monsterSkill)) {
-    console.error('monster skill not assigned');
-    process.exit(1);
-  }
-  const expectedLvl = Math.floor((level - 1) / 3) + 1;
-  if (monster.skillLevels[monster.monsterSkill] !== expectedLvl) {
-    console.error('monster skill level not scaled');
-    process.exit(1);
-  }
+  const tests = [
+    { type: 'ZOMBIE', level: 4 },
+    { type: 'DEMON_WARRIOR', level: 5 }
+  ];
 
-  gameState.monsters.push(monster);
-  gameState.dungeon[1][1] = 'monster';
-  killMonster(monster);
-  gameState.player.gold = 1000;
-  reviveMonsterCorpse(monster);
-  const merc = gameState.activeMercenaries.find(m => m.id === monster.id);
-  if (!merc || merc.skill !== monster.monsterSkill) {
-    console.error('monster skill not kept after revival');
-    process.exit(1);
-  }
-  if (merc.skillLevels[merc.skill] !== expectedLvl) {
-    console.error('skill level not kept after revival');
-    process.exit(1);
+  for (const { type, level } of tests) {
+    const monster = createMonster(type, 1, 1, level);
+    if (!monster.monsterSkill || !MONSTER_SKILL_SETS[type].includes(monster.monsterSkill)) {
+      console.error('monster skill not assigned');
+      process.exit(1);
+    }
+    const expectedLvl = Math.floor((level - 1) / 3) + 1;
+    if (monster.skillLevels[monster.monsterSkill] !== expectedLvl) {
+      console.error('monster skill level not scaled');
+      process.exit(1);
+    }
+
+    gameState.monsters.push(monster);
+    gameState.dungeon[1][1] = 'monster';
+    killMonster(monster);
+    gameState.player.gold = 1000;
+    reviveMonsterCorpse(monster);
+    const merc = gameState.activeMercenaries.find(m => m.id === monster.id);
+    if (!merc || merc.skill !== monster.monsterSkill) {
+      console.error('monster skill not kept after revival');
+      process.exit(1);
+    }
+    if (merc.skillLevels[merc.skill] !== expectedLvl) {
+      console.error('skill level not kept after revival');
+      process.exit(1);
+    }
+
+    gameState.activeMercenaries = [];
+    gameState.monsters = [];
+    gameState.corpses = [];
   }
 }
 


### PR DESCRIPTION
## Summary
- add PoisonCloud and FireBreath monster skills
- assign new skills to several monster races
- allow monsters to spawn with the added skills and keep them when revived
- test new skill assignments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684664fd101083278561469746069454