### PR TITLE
Fix monster skill display for mercenaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -2110,8 +2110,8 @@
                 const accessory2 = merc.equipped && merc.equipped.accessory2 ? merc.equipped.accessory2.name : '없음';
             const totalAttack = formatNumber(getStat(merc, 'attack'));
             const totalDefense = formatNumber(getStat(merc, 'defense'));
-                const skillInfo = MERCENARY_SKILLS[merc.skill];
-                const skillInfo2 = MERCENARY_SKILLS[merc.skill2];
+                const skillInfo = MERCENARY_SKILLS[merc.skill] || MONSTER_SKILLS[merc.skill];
+                const skillInfo2 = MERCENARY_SKILLS[merc.skill2] || MONSTER_SKILLS[merc.skill2];
                 let skillText = skillInfo ? `스킬:${skillInfo.name}(MP ${skillInfo.manaCost})` : '스킬: 없음';
                 if (skillInfo2) skillText += ` / ${skillInfo2.name}(MP ${skillInfo2.manaCost})`;
 
@@ -2141,8 +2141,8 @@
             gameState.standbyMercenaries.forEach((merc, i) => {
                 const div = document.createElement('div');
                 div.className = 'mercenary-info alive';
-                const skillInfo = MERCENARY_SKILLS[merc.skill];
-                const skillInfo2 = MERCENARY_SKILLS[merc.skill2];
+                const skillInfo = MERCENARY_SKILLS[merc.skill] || MONSTER_SKILLS[merc.skill];
+                const skillInfo2 = MERCENARY_SKILLS[merc.skill2] || MONSTER_SKILLS[merc.skill2];
                 let skillText = skillInfo ? `스킬:${skillInfo.name}(MP ${skillInfo.manaCost})` : '스킬: 없음';
                 if (skillInfo2) skillText += ` / ${skillInfo2.name}(MP ${skillInfo2.manaCost})`;
                 div.textContent = `${merc.icon} ${merc.name} (대기) [${skillText}]`;


### PR DESCRIPTION
## Summary
- fix `updateMercenaryDisplay` to look up skills in both `MERCENARY_SKILLS` and `MONSTER_SKILLS`
- now monster skills show proper name and mana cost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846731333bc8327b20a6679107a2e25