### PR TITLE
Add farm planting feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,6 +285,30 @@
             border-radius: 4px;
             font-size: 11px;
         }
+        .farm-panel {
+            background: linear-gradient(135deg, #2a2a2a, #333);
+            padding: 15px;
+            border-radius: 8px;
+            border: 1px solid #555;
+            box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
+            max-height: 200px;
+            overflow-y: auto;
+        }
+        .farm-panel h2 {
+            color: #8BC34A;
+            margin: 0 0 12px 0;
+            border-bottom: 2px solid #8BC34A;
+            padding-bottom: 8px;
+            text-align: center;
+            font-size: 16px;
+        }
+        .farm-slot {
+            background-color: #444;
+            padding: 6px;
+            margin-bottom: 4px;
+            border-radius: 4px;
+            font-size: 11px;
+        }
         .hire-panel h2 {
             color: #FFD700;
             margin: 0 0 12px 0;
@@ -705,6 +729,11 @@
                 <div id="hatched-list"></div>
             </div>
 
+            <div class="farm-panel">
+                <h2>🌾 농장</h2>
+                <div id="farm-slots"></div>
+            </div>
+
             <div class="hire-panel">
                 <h2>💼 용병 고용</h2>
                 <button class="hire-button" onclick="hireMercenary('WARRIOR')">⚔️ 전사 고용 (50💰)</button>
@@ -767,7 +796,8 @@
             POTION: 'potion',
             REVIVE: 'revive',
             EXP_SCROLL: 'expScroll',
-            EGG: 'egg'
+            EGG: 'egg',
+            FERTILIZER: 'fertilizer'
         };
 
         const SHOP_PRICE_MULTIPLIER = 3;
@@ -1242,6 +1272,13 @@
                 icon: '🥚',
                 incubation: 3
             },
+            fertilizer: {
+                name: '🌱 비료',
+                type: ITEM_TYPES.FERTILIZER,
+                price: 5,
+                level: 1,
+                icon: '🌱'
+            },
 
         };
 
@@ -1532,6 +1569,7 @@
             turn: 0,
             incubators: [null, null],
             hatchedSuperiors: [],
+            farms: [null, null, null, null, null, null],
             gameRunning: true
         };
         window.gameState = gameState;
@@ -2298,6 +2336,7 @@
                 <div>악세1: ${accessory1} ${acc1Btn}</div>
                 <div>악세2: ${accessory2} ${acc2Btn}</div>
                 ${skillHtml || '<div>스킬: 없음</div>'}
+                ${(function(){ const idx=gameState.farms.findIndex(f=>!f); return idx!==-1?`<button onclick="plantMonster(window.currentDetailMercenary,${idx})">농장 보내기</button>`:''; })()}
             `;
 
             document.getElementById('mercenary-detail-content').innerHTML = html;
@@ -2926,6 +2965,92 @@ function killMonster(monster) {
                     gameState.incubators[i] = null;
                 }
             });
+        }
+
+        function updateFarmDisplay() {
+            const list = document.getElementById('farm-slots');
+            if (!list) return;
+            list.innerHTML = '';
+            gameState.farms.forEach((slot, i) => {
+                const div = document.createElement('div');
+                div.className = 'farm-slot';
+                if (slot) {
+                    if (slot.remainingTurns > 0) {
+                        div.textContent = `${slot.monster.name} (${slot.remainingTurns}T)`;
+                    } else {
+                        div.textContent = `${slot.monster.name} 수확 가능`;
+                        const btn = document.createElement('button');
+                        btn.textContent = '수확';
+                        btn.className = 'sell-button';
+                        btn.onclick = () => harvestMonster(i);
+                        div.appendChild(btn);
+                    }
+                } else {
+                    div.textContent = '비어 있음';
+                }
+                list.appendChild(div);
+            });
+        }
+
+        function plantMonster(monster, index) {
+            if (gameState.farms[index]) return;
+            if (monster.equipped) {
+                Object.values(monster.equipped).forEach(it => { if (it) addToInventory(it); });
+                monster.equipped = { weapon: null, armor: null, accessory1: null, accessory2: null };
+            }
+            monster.alive = false;
+            const fIndex = gameState.activeMercenaries.indexOf(monster);
+            if (fIndex !== -1) gameState.activeMercenaries.splice(fIndex,1);
+            const sIndex = gameState.standbyMercenaries.indexOf(monster);
+            if (sIndex !== -1) gameState.standbyMercenaries.splice(sIndex,1);
+            const fertIndex = gameState.player.inventory.findIndex(i => i.key === 'fertilizer');
+            let fertilized = false;
+            if (fertIndex !== -1) {
+                gameState.player.inventory.splice(fertIndex,1);
+                fertilized = true;
+            }
+            const turns = monster.isSuperior ? 1 : 5;
+            gameState.farms[index] = { monster, remainingTurns: turns, fertilizer: fertilized };
+            addMessage(`🌱 ${monster.name}을(를) 농장에 심었습니다.`, 'info');
+            updateInventoryDisplay();
+            updateMercenaryDisplay();
+            updateFarmDisplay();
+        }
+
+        function advanceFarms() {
+            gameState.farms.forEach((slot, i) => {
+                if (!slot) return;
+                if (slot.remainingTurns > 0) {
+                    slot.remainingTurns--;
+                    if (slot.remainingTurns === 0) {
+                        addMessage(`🌾 ${slot.monster.name}이(가) 수확 준비되었습니다!`, 'info');
+                    }
+                }
+            });
+        }
+
+        function harvestMonster(index) {
+            const slot = gameState.farms[index];
+            if (!slot || slot.remainingTurns > 0) return;
+            const m = slot.monster;
+            const mult = (0.5 + Math.random() * 0.5) * (slot.fertilizer ? 1.2 : 1);
+            const item = {
+                id: Math.random().toString(36).substr(2,9),
+                name: `${m.name}의 정수`,
+                type: ITEM_TYPES.ACCESSORY,
+                attack: Math.floor(m.attack * mult),
+                defense: Math.floor(m.defense * mult),
+                magicPower: Math.floor(m.magicPower * mult)
+            };
+            const skills = [m.skill, m.skill2, m.auraSkill, m.monsterSkill].filter(Boolean);
+            if (skills.length) {
+                item.skill = skills[Math.floor(Math.random()*skills.length)];
+            }
+            addToInventory(item);
+            addMessage(`🌾 ${item.name}을(를) 수확했습니다!`, 'item');
+            gameState.farms[index] = null;
+            updateFarmDisplay();
+            updateInventoryDisplay();
         }
 
         function recruitHatchedSuperior(monster) {
@@ -4380,6 +4505,8 @@ function killMonster(monster) {
             updateMaterialsDisplay();
             advanceIncubators();
             updateIncubatorDisplay();
+            advanceFarms();
+            updateFarmDisplay();
         }
 
         // 용병 AI (개선됨 - 장비 보너스 적용, 안전성 체크 추가)
@@ -5043,6 +5170,8 @@ function killMonster(monster) {
             updateMercenaryDisplay();
             renderDungeon();
             updateCamera();
+            updateIncubatorDisplay();
+            updateFarmDisplay();
             updateActionButtons();
             addMessage('📁 게임을 불러왔습니다.', 'info');
         }
@@ -5459,6 +5588,7 @@ function killMonster(monster) {
             updateInventoryDisplay();
             updateSkillDisplay();
             updateIncubatorDisplay();
+            updateFarmDisplay();
             updateMaterialsDisplay();
             updateActionButtons();
         }


### PR DESCRIPTION
## Summary
- add farm UI with six slots
- include fertilizer item type and item
- extend game state with farms array
- implement planting, advancing, and harvesting monsters
- update displays and game loop for new farm system

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846813b52808327ab816661b7eb4bae