### PR TITLE
Remove pretest script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install
 
 ## Testing
 
-Run `npm install` to install **jsdom** and other dependencies, then execute `npm test` to run the test suite.
+Install dependencies manually with `npm install` before running `npm test` to execute the suite.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "pretest": "npm install",
     "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js && node tests/itemTargetPrompt.test.js && node tests/elite.test.js && node tests/superior.test.js && node tests/monsterSkill.test.js && node tests/statusEffects.test.js && node tests/monsterFarm.test.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- remove `pretest` step from `package.json`
- clarify in README that dependencies must be installed manually before running the tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68468abc4f1083278a3b2c3c8111f08b