### PR TITLE
Remove pretest install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ npm install
 
 ## Testing
 
-Run `npm install` to install **jsdom** and other dependencies, then execute `npm test` to run the test suite.
+Before running the tests you must install the project dependencies manually:
+
+```bash
+npm install
+```
+
+After installation execute `npm test` to run the test suite.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
-    "pretest": "npm install",
     "test": "node tests/dice.test.js && node tests/mercenaryFollow.test.js && node tests/jobSkills.test.js && node tests/jobSkillsAll.test.js && node tests/mana.test.js && node tests/homingProjectile.test.js && node tests/magicProjectile.test.js && node tests/magicScaling.test.js && node tests/prefixSuffix.test.js && node tests/healSelf.test.js && node tests/mercenarySkill.test.js && node tests/mercenaryStars.test.js && node tests/clickMovement.test.js && node tests/messageDetail.test.js && node tests/champion.test.js && node tests/nova.test.js && node tests/expScroll.test.js && node tests/mercenarySkillUpgrade.test.js && node tests/reviveCorpse.test.js && node tests/itemDropAdjacent.test.js && node tests/itemTargetPrompt.test.js && node tests/elite.test.js && node tests/superior.test.js && node tests/monsterSkill.test.js && node tests/statusEffects.test.js && node tests/monsterFarm.test.js && node tests/aura.test.js && node tests/monsterExp.test.js && node tests/monsterTrait.test.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- remove `pretest` from `package.json`
- clarify README that dependencies must be installed manually before running tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68468eaf39a483279e4de9f39f6a9323