### PR TITLE
Remove skills from harvested items

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2155,10 +2155,6 @@ function killMonster(monster) {
                 defense: Math.floor(m.defense * mult),
                 magicPower: Math.floor(m.magicPower * mult)
             };
-            const skills = [m.skill, m.skill2, m.auraSkill, m.monsterSkill].filter(Boolean);
-            if (skills.length) {
-                item.skill = skills[Math.floor(Math.random()*skills.length)];
-            }
             addToInventory(item);
             addMessage(`🌾 ${item.name}을(를) 수확했습니다!`, 'item');
             gameState.farms[index] = null;

--- a/tests/monsterFarm.test.js
+++ b/tests/monsterFarm.test.js
@@ -57,6 +57,10 @@ async function run() {
     console.error('fertilizer effect on stats missing');
     process.exit(1);
   }
+  if ('skill' in essence) {
+    console.error('harvested essence should not have a skill property');
+    process.exit(1);
+  }
 }
 
 run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- stop attaching random skills when harvesting monsters
- test that harvested essences do not have skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846919210f88327a6cebb5b0dab0c2f