### PR TITLE
Add damage dice to HawkEye mercenary skill

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -519,7 +519,7 @@
             Purify: { name: 'Purify', icon: '🌀', range: 2, manaCost: 2 },
             Fireball: { name: 'Fireball', icon: '🔥', range: 4, manaCost: 3, damageDice: '1d8', magic: true, element: 'fire' },
             Iceball: { name: 'Iceball', icon: '❄️', range: 5, manaCost: 2, damageDice: '1d8', magic: true, element: 'ice' },
-            HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2 },
+            HawkEye: { name: 'Hawk Eye', icon: '🦅', range: 5, manaCost: 2, damageDice: '1d6' },
             RegenerationAura: { name: 'Regeneration Aura', icon: '💚', passive: true, radius: 6, aura: { healthRegen: 1 } },
             MeditationAura: { name: 'Meditation Aura', icon: '🌀', passive: true, radius: 6, aura: { manaRegen: 1 } },
             HasteAura: { name: 'Haste Aura', icon: '💨', passive: true, radius: 6, aura: { evasion: 0.05 } },


### PR DESCRIPTION
## Summary
- ensure HawkEye mercenary skill has matching damageDice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68469723b3a8832787c9b15a5bf283d1