### PR TITLE
Fix game initialization for module scripts

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -97,4 +97,4 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, MERCENARY_TRIGGER_DISTANCE };
   }
-})(this);
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- ensure `state.js` works in module context by referencing `globalThis`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68469b30abbc8327958004b05f5f0f0f