### PR TITLE
Implement new game button reload functionality

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4638,6 +4638,14 @@ function killMonster(monster) {
         startGame();
         document.getElementById('save-game').onclick = saveGame;
         document.getElementById('load-game').onclick = loadGame;
+        const newBtn = document.getElementById('new-game');
+        if (newBtn) {
+            newBtn.onclick = () => {
+                if (typeof confirm !== 'function' || confirm('새 게임을 시작하시겠습니까? 진행 중인 내용이 사라집니다.')) {
+                    location.reload();
+                }
+            };
+        }
         document.getElementById('attack').onclick = meleeAttackAction;
         document.getElementById('ranged').onclick = rangedAction;
         document.getElementById('skill1').onclick = skill1Action;


### PR DESCRIPTION
## Summary
- wire up the **새 게임** button
- prompt before starting a fresh game and reload on confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846a9e2e844832793259cfbbbf0959c