### PR TITLE
Show monster details in incubator slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -458,6 +458,7 @@
             border-left-color: #2196F3;
         }
         .message.clickable { cursor: pointer; text-decoration: underline; }
+        .clickable { cursor: pointer; }
         .controls {
             display: flex;
             flex-direction: column;

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1388,12 +1388,13 @@
             waiting.innerHTML = '';
             gameState.hatchedSuperiors.forEach(mon => {
                 const div = document.createElement('div');
-                div.className = 'incubator-slot';
+                div.className = 'incubator-slot clickable';
                 div.textContent = mon.name;
+                div.onclick = () => showMonsterDetails(mon);
                 const btn = document.createElement('button');
                 btn.textContent = '영입';
                 btn.className = 'sell-button';
-                btn.onclick = () => recruitHatchedSuperior(mon);
+                btn.onclick = (e) => { e.stopPropagation(); recruitHatchedSuperior(mon); };
                 div.appendChild(btn);
                 waiting.appendChild(div);
             });


### PR DESCRIPTION
## Summary
- allow clicking hatched superiors in the incubator to open their detail panel
- prevent recruit button clicks from also opening the detail panel
- indicate clickable incubator slots with a new `.clickable` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846c5c9291c83279ba97720f67518ba