### PR TITLE
Slow affinity gain

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ loyalty to the party.
 
 - Newly hired mercenaries start with **50** affinity.
 - Revived monsters start with **30** affinity.
-- Affinity rises slowly each turn a unit stays in your party and caps at **200**.
+- Affinity rises by **0.01** each turn a unit stays in your party and caps at **200**.
 - When a mercenary dies they lose **5** affinity. If their affinity drops to zero
   they permanently leave your party.
 

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3447,9 +3447,10 @@ function killMonster(monster) {
         function processTurn() {
             if (!gameState.gameRunning) return;
             gameState.turn++;
+            const AFFINITY_PER_TURN = 0.01;
             gameState.activeMercenaries.forEach(m => {
                 if (m.alive) {
-                    m.affinity = Math.min(200, (m.affinity || 0) + 1);
+                    m.affinity = Math.min(200, (m.affinity || 0) + AFFINITY_PER_TURN);
                 }
             });
             processProjectiles();


### PR DESCRIPTION
## Summary
- make affinity increase only by 0.01 each turn
- note the new affinity growth rate in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846c8631e808327a9e1f0dc5c6229f1