### PR TITLE
Handle essence and food items

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -6,7 +6,9 @@
             REVIVE: 'revive',
             EXP_SCROLL: 'expScroll',
             EGG: 'egg',
-            FERTILIZER: 'fertilizer'
+            FERTILIZER: 'fertilizer',
+            ESSENCE: 'essence',
+            FOOD: 'food'
         };
 
         const SHOP_PRICE_MULTIPLIER = 3;
@@ -3085,6 +3087,47 @@ function killMonster(monster) {
                     updateStats();
                 } else {
                     checkMercenaryLevelUp(target);
+                    updateMercenaryDisplay();
+                }
+            } else if (item.type === ITEM_TYPES.ESSENCE) {
+                const stats = ['strength','agility','endurance','focus','intelligence','attack','defense','accuracy','evasion','critChance','magicPower','magicResist','maxHealth','maxMana','healthRegen','manaRegen'];
+                stats.forEach(stat => {
+                    if (item[stat] !== undefined) {
+                        target[stat] = (target[stat] || 0) + item[stat];
+                    }
+                });
+                if (item.skillLevelEssence) {
+                    target.skillPoints = (target.skillPoints || 0) + item.skillLevelEssence;
+                }
+
+                const name = target === gameState.player ? '플레이어' : target.name;
+                addMessage(`✨ ${item.name}을(를) 사용하여 ${name}의 능력치를 향상시켰습니다.`, 'item');
+
+                const index = gameState.player.inventory.findIndex(i => i.id === item.id);
+                if (index !== -1) {
+                    gameState.player.inventory.splice(index, 1);
+                }
+
+                updateInventoryDisplay();
+                if (target === gameState.player) {
+                    updateStats();
+                } else {
+                    updateMercenaryDisplay();
+                }
+            } else if (item.type === ITEM_TYPES.FOOD) {
+                const gain = item.affinityGain || 0;
+                target.affinity = Math.min(200, (target.affinity || 0) + gain);
+
+                const name = target === gameState.player ? '플레이어' : target.name;
+                addMessage(`🍖 ${item.name}을(를) 먹여 ${name}의 호감도를 ${formatNumber(gain)} 상승시켰습니다.`, 'item');
+
+                const index = gameState.player.inventory.findIndex(i => i.id === item.id);
+                if (index !== -1) {
+                    gameState.player.inventory.splice(index, 1);
+                }
+
+                updateInventoryDisplay();
+                if (target !== gameState.player) {
                     updateMercenaryDisplay();
                 }
             }


### PR DESCRIPTION
## Summary
- add `ESSENCE` and `FOOD` item types
- allow essences to boost stats or skill points
- let food increase affinity

## Testing
- `npm install`
- `npm test` *(fails: aura bonus not applied)*

------
https://chatgpt.com/codex/tasks/task_e_6846cb61901883279bcc7143892afa87