### PR TITLE
Add zombie mercenary at start

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -6,7 +6,8 @@
             REVIVE: 'revive',
             EXP_SCROLL: 'expScroll',
             EGG: 'egg',
-            FERTILIZER: 'fertilizer'
+            FERTILIZER: 'fertilizer',
+            FOOD: 'food'
         };
 
         const SHOP_PRICE_MULTIPLIER = 3;
@@ -487,6 +488,13 @@
                 price: 5,
                 level: 1,
                 icon: '🌱'
+            },
+            food: {
+                name: '🍲 요리',
+                type: ITEM_TYPES.FOOD,
+                price: 1,
+                level: 1,
+                icon: '🍲'
             },
 
         };
@@ -4726,6 +4734,19 @@ function killMonster(monster) {
             generateDungeon();
             for (let i = 0; i < 5; i++) {
                 gameState.player.inventory.push(createItem('smallExpScroll', 0, 0));
+            }
+            const z = createMonster('ZOMBIE', 0, 0, 1);
+            const merc = convertMonsterToMercenary(z);
+            merc.affinity = 195;
+            gameState.activeMercenaries.push(merc);
+            spawnMercenaryNearPlayer(merc);
+            for (let i = 0; i < 5; i++) {
+                gameState.player.inventory.push({
+                    id: Math.random().toString(36).substr(2, 9),
+                    name: '요리',
+                    type: ITEM_TYPES.FOOD,
+                    icon: '🍲'
+                });
             }
             updateInventoryDisplay();
             updateSkillDisplay();

--- a/tests/itemTargetPrompt.test.js
+++ b/tests/itemTargetPrompt.test.js
@@ -12,6 +12,7 @@ async function run() {
 
   const { hireMercenary, createItem, addToInventory, handleItemClick, gameState } = win;
 
+  gameState.activeMercenaries = [];
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
 

--- a/tests/mercenaryFollow.test.js
+++ b/tests/mercenaryFollow.test.js
@@ -15,6 +15,7 @@ async function run() {
 
   // ensure enough gold for hiring
   gameState.player.gold = 200;
+  gameState.activeMercenaries = [];
 
   hireMercenary('WARRIOR');
   hireMercenary('ARCHER');

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -28,6 +28,7 @@ async function run() {
   gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
   gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
   gameState.monsters = [];
+  gameState.activeMercenaries = [];
   gameState.player.x = 1;
   gameState.player.y = 1;
   gameState.dungeon[1][1] = 'empty';

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -27,6 +27,7 @@ async function run() {
   gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
   gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
   gameState.monsters = [];
+  gameState.activeMercenaries = [];
   gameState.player.x = 1;
   gameState.player.y = 1;
   gameState.dungeon[1][1] = 'empty';

--- a/tests/mercenaryStars.test.js
+++ b/tests/mercenaryStars.test.js
@@ -11,6 +11,7 @@ async function run() {
 
   const { hireMercenary, gameState, checkMercenaryLevelUp, showMercenaryDetails, saveGame, loadGame: loadGameGame, localStorage } = win;
 
+  gameState.activeMercenaries = [];
   gameState.player.gold = 500;
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];

--- a/tests/monsterExp.test.js
+++ b/tests/monsterExp.test.js
@@ -15,6 +15,7 @@ async function run() {
   gameState.dungeonSize = size;
   gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
   gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.activeMercenaries = [];
   gameState.player.x = 2;
   gameState.player.y = 2;
 


### PR DESCRIPTION
## Summary
- allow `FOOD` item type and define a simple food item
- spawn a zombie mercenary at game start and give player five food items
- clear test mercenaries before hiring to accommodate the new default mercenary

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846cb66ed9083278019b1661cf9e28a