### PR TITLE
Add sacrifice mechanics and tests

### DIFF
--- a/tests/itemTargetPrompt.test.js
+++ b/tests/itemTargetPrompt.test.js
@@ -12,6 +12,7 @@ async function run() {
 
   const { hireMercenary, createItem, addToInventory, handleItemClick, gameState } = win;
 
+  gameState.activeMercenaries = [];
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
 

--- a/tests/mercenaryFollow.test.js
+++ b/tests/mercenaryFollow.test.js
@@ -15,6 +15,7 @@ async function run() {
 
   // ensure enough gold for hiring
   gameState.player.gold = 200;
+  gameState.activeMercenaries = [];
 
   hireMercenary('WARRIOR');
   hireMercenary('ARCHER');

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -32,6 +32,7 @@ async function run() {
   gameState.player.y = 1;
   gameState.dungeon[1][1] = 'empty';
 
+  gameState.activeMercenaries = [];
   hireMercenary('WIZARD');
   const merc = gameState.activeMercenaries[0];
 

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -31,6 +31,7 @@ async function run() {
   gameState.player.y = 1;
   gameState.dungeon[1][1] = 'empty';
 
+  gameState.activeMercenaries = [];
   hireMercenary('HEALER');
   const merc = gameState.activeMercenaries[0];
   const skillKey = merc.skill;

--- a/tests/mercenaryStars.test.js
+++ b/tests/mercenaryStars.test.js
@@ -12,6 +12,7 @@ async function run() {
   const { hireMercenary, gameState, checkMercenaryLevelUp, showMercenaryDetails, saveGame, loadGame: loadGameGame, localStorage } = win;
 
   gameState.player.gold = 500;
+  gameState.activeMercenaries = [];
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
 

--- a/tests/monsterExp.test.js
+++ b/tests/monsterExp.test.js
@@ -19,6 +19,7 @@ async function run() {
   gameState.player.y = 2;
 
   gameState.player.gold = 1000;
+  gameState.activeMercenaries = [];
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
   merc.x = 3;

--- a/tests/sacrifice.test.js
+++ b/tests/sacrifice.test.js
@@ -1,0 +1,53 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, showMercenaryDetails, sacrificeMercenary, useItemOnTarget } = win;
+
+  const zombie = gameState.activeMercenaries.find(m => m.name.includes('좀비'));
+  if (!zombie || zombie.affinity !== 195) {
+    console.error('zombie mercenary not initialized');
+    process.exit(1);
+  }
+  const meals = gameState.player.inventory.filter(i => i.key === 'meal');
+  if (meals.length !== 5) {
+    console.error('starting meals incorrect');
+    process.exit(1);
+  }
+
+  zombie.affinity = 200;
+  showMercenaryDetails(zombie);
+  const html = win.document.getElementById('mercenary-detail-content').innerHTML;
+  if (!html.includes('희생')) {
+    console.error('sacrifice button missing');
+    process.exit(1);
+  }
+
+  sacrificeMercenary(zombie);
+  if (gameState.activeMercenaries.includes(zombie)) {
+    console.error('mercenary not removed after sacrifice');
+    process.exit(1);
+  }
+  const essences = gameState.player.inventory.filter(i => i.key === 'strengthEssence');
+  if (essences.length !== 1) {
+    console.error('essence not granted');
+    process.exit(1);
+  }
+
+  const before = gameState.player.strength;
+  useItemOnTarget(essences[0], gameState.player);
+  if (gameState.player.strength !== before + 1) {
+    console.error('essence not used correctly');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- expand item types with food and essence and add new items
- spawn a zombie mercenary with high affinity and starting food
- enable sacrificing mercenaries to receive an essence item
- let essence items boost stats and show sacrifice button in details
- update tests for new start state and add a new sacrifice test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846cb686c748327bfee45f53533e552