### PR TITLE
Fix food item targeting

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4795,7 +4795,9 @@ function killMonster(monster) {
                 dead.forEach(m => {
                     addBtn(m.name, () => reviveMercenary(m));
                 });
-            } else if (item.type === ITEM_TYPES.POTION || item.type === ITEM_TYPES.EXP_SCROLL) {
+            } else if (item.type === ITEM_TYPES.POTION ||
+                       item.type === ITEM_TYPES.EXP_SCROLL ||
+                       item.type === ITEM_TYPES.FOOD) {
                 addBtn('플레이어', () => useItemOnTarget(item, gameState.player));
                 gameState.activeMercenaries.forEach(m => {
                     addBtn(m.name, () => useItemOnTarget(item, m));


### PR DESCRIPTION
## Summary
- allow food items to be used on mercenaries and player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846db6b5b7c832786c7771cd8911a4f