### PR TITLE
Add starter cooking materials and boost mercenary AI

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -538,6 +538,42 @@
                 level: 1,
                 icon: '⭐'
             },
+            bread: {
+                name: '🍞 Bread',
+                type: ITEM_TYPES.FOOD,
+                affinityGain: 3,
+                fullnessGain: 2,
+                price: 5,
+                level: 1,
+                icon: '🍞'
+            },
+            carrot: {
+                name: '🥕 Carrot',
+                type: ITEM_TYPES.FOOD,
+                affinityGain: 2,
+                fullnessGain: 1,
+                price: 3,
+                level: 1,
+                icon: '🥕'
+            },
+            milk: {
+                name: '🥛 Milk',
+                type: ITEM_TYPES.FOOD,
+                affinityGain: 2,
+                fullnessGain: 1,
+                price: 3,
+                level: 1,
+                icon: '🥛'
+            },
+            sandwich: {
+                name: '🥪 Sandwich',
+                type: ITEM_TYPES.FOOD,
+                affinityGain: 15,
+                fullnessGain: 8,
+                price: 20,
+                level: 1,
+                icon: '🥪'
+            },
             cookedMeal: {
                 name: '🍲 요리',
                 type: ITEM_TYPES.FOOD,
@@ -640,7 +676,8 @@
 
         const RECIPES = {
             healthPotion: { name: 'Health Potion', output: 'healthPotion', materials: { herb: 2 }, turns: 3 },
-            shortSword: { name: 'Short Sword', output: 'shortSword', materials: { wood: 1, iron: 2 }, turns: 5 }
+            shortSword: { name: 'Short Sword', output: 'shortSword', materials: { wood: 1, iron: 2 }, turns: 5 },
+            sandwich: { name: 'Sandwich', output: 'sandwich', materials: { bread: 1, carrot: 1, milk: 1 }, turns: 2 }
         };
 
 

--- a/src/state.js
+++ b/src/state.js
@@ -1,7 +1,8 @@
 (function(global){
   const MONSTER_VISION = 6;
   const FOG_RADIUS = 6; // increased player vision range
-  const MERCENARY_TRIGGER_DISTANCE = 5; // player distance to trigger ally attacks
+  // Mercenaries should react to any monster the player can see
+  const MERCENARY_TRIGGER_DISTANCE = FOG_RADIUS;
   const gameState = {
     dungeon: [],
     fogOfWar: [],
@@ -77,8 +78,8 @@
     exitLocation: { x: 0, y: 0 },
     shopLocation: { x: 0, y: 0 },
     shopItems: [],
-    materials: { herb: 5, wood: 3, iron: 0 },
-    knownRecipes: ['healthPotion'],
+    materials: { herb: 5, wood: 3, iron: 0, bread: 2, carrot: 2, milk: 2 },
+    knownRecipes: ['healthPotion', 'sandwich'],
     craftingQueue: [],
     floor: 1,
     dungeonSize: 80,


### PR DESCRIPTION
## Summary
- extend mercenary trigger distance to match player vision
- start game with bread, carrot, and milk materials and a Sandwich recipe
- define Bread, Carrot, Milk and Sandwich items and recipe

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6846e97bab4883278a05afa0e539ab02