### PR TITLE
Add fullness display

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,6 +710,7 @@
                 <div>📖 지능: <span id="intelligenceStat">0</span></div>
                 <div>❤️ 체력: <span id="health">20</span>/<span id="maxHealth">20</span></div>
                 <div>🔋 마나: <span id="mana">10</span>/<span id="maxMana">10</span></div>
+                <div>🍗 배부름: <span id="fullness">0</span></div>
                 <div>❤️‍🩹 회복력: <span id="healthRegen">0</span></div>
                 <div>🔁 마나회복: <span id="manaRegen">1</span></div>
                 <div>⚔️ 공격력: <span id="attackStat">5</span> <span id="weaponBonus"></span></div>

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1561,6 +1561,7 @@
                 <div>🔮 집중: ${formatNumber(merc.focus)} ${'★'.repeat(merc.stars.focus)}</div>
                 <div>📖 지능: ${formatNumber(merc.intelligence)} ${'★'.repeat(merc.stars.intelligence)}</div>
                 <div>💕 호감도: ${formatNumber(merc.affinity)}</div>
+                <div>🍗 배부름: ${formatNumber(merc.fullness)}</div>
                 <hr>
                 <div>❤️ HP: ${formatNumber(merc.health)}/${formatNumber(getStat(merc, 'maxHealth'))}</div>
                 <div>🔋 MP: ${formatNumber(merc.mana)}/${formatNumber(getStat(merc, 'maxMana'))}</div>
@@ -1646,6 +1647,7 @@
                 <div>🔮 마법공격: ${formatNumber(getStat(monster,'magicPower'))}</div>
                 <div>✨ 마법방어: ${formatNumber(getStat(monster,'magicResist'))}</div>
                 ${monster.affinity !== undefined ? `<div>💕 호감도: ${formatNumber(monster.affinity)}</div>` : ''}
+                ${monster.fullness !== undefined ? `<div>🍗 배부름: ${formatNumber(monster.fullness)}</div>` : ''}
                 <div>💪 힘: ${monster.strength}${monster.isSuperior ? ' ' + '★'.repeat(stars.strength) : ''}</div>
                 <div>🏃 민첩: ${monster.agility}${monster.isSuperior ? ' ' + '★'.repeat(stars.agility) : ''}</div>
                 <div>🛡 체력: ${monster.endurance}${monster.isSuperior ? ' ' + '★'.repeat(stars.endurance) : ''}</div>
@@ -1764,6 +1766,7 @@
             document.getElementById('maxHealth').textContent = formatNumber(getStat(gameState.player, 'maxHealth'));
             document.getElementById('mana').textContent = formatNumber(gameState.player.mana);
             document.getElementById('maxMana').textContent = formatNumber(getStat(gameState.player, 'maxMana'));
+            document.getElementById('fullness').textContent = formatNumber(gameState.player.fullness);
             document.getElementById('healthRegen').textContent = formatNumber(getStat(gameState.player, 'healthRegen'));
             document.getElementById('manaRegen').textContent = formatNumber(getStat(gameState.player, 'manaRegen'));
             document.getElementById('attackStat').textContent = formatNumber(getStat(gameState.player, 'attack'));


### PR DESCRIPTION
## Summary
- show fullness in mercenary details panel
- add fullness to monster details
- display player fullness in stats panel
- track player fullness in updateStats()

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fbfc56d483279a364d645a4c51ac