### PR TITLE
Increase shop variety

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,6 +545,11 @@
             z-index: 100;
             min-width: 200px;
         }
+        #shop-items {
+            max-height: 200px;
+            overflow-y: auto;
+            margin-bottom: 10px;
+        }
         .details-panel {
             position: absolute;
             top: 50%;

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2697,7 +2697,14 @@ function killMonster(monster) {
 
             gameState.shopItems = [];
             const availableItems = itemKeys.filter(k => ITEMS[k].level <= Math.ceil(gameState.floor / 2 + 1));
-            for (let i = 0; i < 3; i++) {
+            const basicFoodKeys = ['bread', 'meat', 'lettuce', 'sandwich', 'salad', 'cookedMeal'];
+            basicFoodKeys.forEach(key => {
+                if (ITEMS[key] && !availableItems.includes(key)) {
+                    availableItems.push(key);
+                }
+            });
+            const shopItemCount = 5 + Math.floor(Math.random() * 5); // 5-9 items
+            for (let i = 0; i < shopItemCount; i++) {
                 const k = availableItems[Math.floor(Math.random() * availableItems.length)];
                 const shopItem = createItem(k, 0, 0);
                 gameState.shopItems.push(shopItem);


### PR DESCRIPTION
## Summary
- generate more shop items (random 5-9)
- always include basic foods when populating shop options
- make shop items panel scrollable so extra items fit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fbfddb9083278e091ae38a471fa0