### PR TITLE
Add harvestable plant tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,11 @@
             color: white;
             box-shadow: 0 0 6px rgba(149, 117, 205, 0.5);
         }
+        .plant {
+            background: radial-gradient(circle, #4CAF50, #2E7D32);
+            color: #e8f5e9;
+            box-shadow: 0 0 6px rgba(76, 175, 80, 0.5);
+        }
         .projectile {
             background: radial-gradient(circle, #ff9800, #e65100);
             color: white;

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2396,6 +2396,8 @@ function killMonster(monster) {
                             } else if (cellType === 'item') {
                                 const it = gameState.items.find(it => it.x === x && it.y === y);
                                 if (it) div.textContent = it.icon;
+                            } else if (cellType === 'plant') {
+                                div.textContent = '🌿';
                             } else if (cellType === 'corpse') {
                                 div.textContent = '☠️';
                             } else if (cellType === 'treasure') {
@@ -2683,6 +2685,16 @@ function killMonster(monster) {
                 const item = createItem(key, x, y);
                 gameState.items.push(item);
                 gameState.dungeon[y][x] = 'item';
+            }
+
+            const plantCount = Math.floor(size * 0.05);
+            for (let i = 0; i < plantCount; i++) {
+                let x, y;
+                do {
+                    x = Math.floor(Math.random() * size);
+                    y = Math.floor(Math.random() * size);
+                } while (gameState.dungeon[y][x] !== 'empty');
+                gameState.dungeon[y][x] = 'plant';
             }
 
 
@@ -3537,6 +3549,21 @@ function killMonster(monster) {
                     }
                     gameState.dungeon[newY][newX] = 'empty';
                 }
+            }
+
+            if (cellType === 'plant') {
+                const materialsPool = ['herb', 'bread', 'meat', 'lettuce'];
+                const gained = [];
+                const count = Math.floor(Math.random() * 2) + 1;
+                for (let i = 0; i < count; i++) {
+                    const mat = materialsPool[Math.floor(Math.random() * materialsPool.length)];
+                    if (!gameState.materials[mat]) gameState.materials[mat] = 0;
+                    gameState.materials[mat] += 1;
+                    gained.push(mat);
+                }
+                addMessage(`🌿 식물을 채집하여 ${gained.join(', ')}을(를) 얻었습니다.`, 'item');
+                gameState.dungeon[newY][newX] = 'empty';
+                updateMaterialsDisplay();
             }
 
             if (cellType === 'corpse') {


### PR DESCRIPTION
## Summary
- add `.plant` style for dungeon grid
- spawn `plant` tiles during dungeon generation
- display plants in `renderDungeon`
- harvest random materials when stepping on plant tiles

## Testing
- `npm install jsdom`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fbfe132c832794fd59cfd065d038