### PR TITLE
Implement maze-based dungeon layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This project is a lightweight browser-based dungeon crawler. It lets players exp
 
 Open `index.html` in a modern web browser to start the game. The player now begins with every available skill already learned, so no class selection is required.
 
+### Dungeon Generation
+
+Each floor is carved from a fully walled grid using a depth-first search maze algorithm. Corridors are six tiles wide and several 15×15 rooms are added along the explored path. The exit is placed on a random visited cell so every floor is fully traversable.
+
 
 ### Controls
 


### PR DESCRIPTION
## Summary
- generate wider corridors using a DFS maze algorithm
- carve 15×15 rooms along the maze
- pick the exit from visited cells so it is always reachable
- document the maze generation in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470d811cc08327a9a24b642b52a8ea