### PR TITLE
Fix incubator display click details

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1548,6 +1548,7 @@ const MERCENARY_NAMES = ['Aldo', 'Borin', 'Cara', 'Dain', 'Elin', 'Faris'];
                 const div = document.createElement('div');
                 div.className = 'incubator-slot clickable';
                 div.textContent = mon.name;
+                div.onclick = () => showMonsterDetails(mon);
                 div.dataset.id = mon.id;
                 const btn = document.createElement('button');
                 btn.textContent = '영입';
@@ -1558,18 +1559,7 @@ const MERCENARY_NAMES = ['Aldo', 'Borin', 'Cara', 'Dain', 'Elin', 'Faris'];
             });
         }
 
-        document.getElementById('hatched-list').addEventListener('click', (e) => {
-            const slot = e.target.closest('.incubator-slot');
-            if (!slot) return;
-            const id = slot.dataset.id;
-            if (!id) return;
-            const monster = gameState.hatchedSuperiors.find(m => String(m.id) === id);
-            if (monster) {
-                showMonsterDetails(monster);
-            } else {
-                console.warn('Monster not found or undefined:', id);
-            }
-        });
+
 
         // 용병 상세 정보 표시
         function showMercenaryDetails(merc) {


### PR DESCRIPTION
## Summary
- enable clicking hatched monsters to view details
- remove unused incubator click handler

## Testing
- `npm test` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68473a88b9d88327b78e3620b138a45c