### PR TITLE
Fix initial stats refresh

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5172,6 +5172,7 @@ function processTurn() {
             updateIncubatorDisplay();
             updateMaterialsDisplay();
             updateActionButtons();
+            updateStats();
         }
 
         // 초기화 및 입력 처리


### PR DESCRIPTION
## Summary
- update the `startGame` method to call `updateStats` after other UI refreshes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847917a30888327b1cf479120d708f0