### PR TITLE
Add item enhancement system

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -81,7 +81,7 @@
     exitLocation: { x: 0, y: 0 },
     shopLocation: { x: 0, y: 0 },
     shopItems: [],
-    materials: { herb: 5, wood: 3, iron: 0, bread: 0, meat: 0, lettuce: 0 },
+    materials: { herb: 5, wood: 3, iron: 0, bone: 0, bread: 0, meat: 0, lettuce: 0 },
     knownRecipes: ['healthPotion', 'sandwich', 'salad'],
     craftingQueue: [],
     floor: 1,


### PR DESCRIPTION
## Summary
- track new `bone` material in game state
- extend `createItem` to support enhance levels and base stat storage
- implement `enhanceItem` with scaling costs and stat boosts
- display equipment enhancement level in inventory
- drop enhanced gear based on floor level

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a6dcae2483278ad41f2d457366d9