### PR TITLE
Fix aura info lookup in monster details

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1870,7 +1870,11 @@ const MERCENARY_NAMES = [
         }
 
         function showMonsterDetails(monster) {
-            const auraInfo = monster.isElite && monster.auraSkill ? SKILL_DEFS[monster.auraSkill] : null;
+            const auraInfo = monster.isElite && monster.auraSkill
+                ? (SKILL_DEFS[monster.auraSkill] ||
+                   MERCENARY_SKILLS[monster.auraSkill] ||
+                   MONSTER_SKILLS[monster.auraSkill])
+                : null;
             const lvl = monster.skillLevels[monster.auraSkill] || 1;
             const auraLine = auraInfo
                 ? `<div>오라 스킬: <span class="merc-skill"


### PR DESCRIPTION
## Summary
- allow aura info lookup for all skill maps
- npm install
- npm test (fails: `affinity.test.js`)

## Testing
- `npm install`
- `npm test` *(fails: affinity.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847afcbe1308327b3a7bb177a37a4d1