### PR TITLE
Enable unequipping starting gear

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1502,14 +1502,18 @@ const MERCENARY_NAMES = [
             const weaponSlot = document.getElementById('equipped-weapon');
             if (gameState.player.equipped.weapon) {
                 weaponSlot.textContent = `무기: ${formatItem(gameState.player.equipped.weapon)}`;
+                weaponSlot.onclick = unequipWeapon;
             } else {
                 weaponSlot.textContent = '무기: 없음';
+                weaponSlot.onclick = null;
             }
             const armorSlot = document.getElementById('equipped-armor');
             if (gameState.player.equipped.armor) {
                 armorSlot.textContent = `방어구: ${formatItem(gameState.player.equipped.armor)}`;
+                armorSlot.onclick = unequipArmor;
             } else {
                 armorSlot.textContent = '방어구: 없음';
+                armorSlot.onclick = null;
             }
             const acc1Slot = document.getElementById('equipped-accessory1');
             if (gameState.player.equipped.accessory1) {
@@ -3518,6 +3522,28 @@ function killMonster(monster) {
             if (item) {
                 addToInventory(item);
                 gameState.player.equipped[slot] = null;
+                addMessage(`📦 ${item.name}을(를) 해제했습니다.`, 'item');
+                updateInventoryDisplay();
+                updateStats();
+            }
+        }
+
+        function unequipWeapon() {
+            const item = gameState.player.equipped.weapon;
+            if (item) {
+                addToInventory(item);
+                gameState.player.equipped.weapon = null;
+                addMessage(`📦 ${item.name}을(를) 해제했습니다.`, 'item');
+                updateInventoryDisplay();
+                updateStats();
+            }
+        }
+
+        function unequipArmor() {
+            const item = gameState.player.equipped.armor;
+            if (item) {
+                addToInventory(item);
+                gameState.player.equipped.armor = null;
                 addMessage(`📦 ${item.name}을(를) 해제했습니다.`, 'item');
                 updateInventoryDisplay();
                 updateStats();
@@ -5538,7 +5564,7 @@ rollDice, saveGame, sellItem, enhanceItem, setMercenaryLevel, setMonsterLevel, s
 showChampionDetails, showItemTargetPanel, showMercenaryDetails,
 showMonsterDetails, showShop, showSkillDamage, showAuraDetails, skill1Action, skill2Action,
 spawnMercenaryNearPlayer, startGame, swapActiveAndStandby, tryApplyStatus,
-unequipAccessory, unequipItemFromMercenary, updateActionButtons, updateCamera,
+unequipAccessory, unequipWeapon, unequipArmor, unequipItemFromMercenary, updateActionButtons, updateCamera,
 updateFogOfWar, updateIncubatorDisplay,
 updateInventoryDisplay, updateMaterialsDisplay, updateMercenaryDisplay,
 updateShopDisplay, updateSkillDisplay, updateStats, updateTurnEffects,

--- a/tests/unequip.test.js
+++ b/tests/unequip.test.js
@@ -1,0 +1,44 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, unequipWeapon, unequipArmor } = win;
+
+  const weapon = gameState.player.equipped.weapon;
+  const armor = gameState.player.equipped.armor;
+  if (!weapon || !armor) {
+    console.error('starting equipment missing');
+    process.exit(1);
+  }
+
+  const invBefore = gameState.player.inventory.length;
+  unequipWeapon();
+  if (gameState.player.equipped.weapon !== null) {
+    console.error('weapon not unequipped');
+    process.exit(1);
+  }
+  if (!gameState.player.inventory.includes(weapon) || gameState.player.inventory.length !== invBefore + 1) {
+    console.error('weapon not added to inventory');
+    process.exit(1);
+  }
+
+  unequipArmor();
+  if (gameState.player.equipped.armor !== null) {
+    console.error('armor not unequipped');
+    process.exit(1);
+  }
+  if (!gameState.player.inventory.includes(armor) || gameState.player.inventory.length !== invBefore + 2) {
+    console.error('armor not added to inventory');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- support removing equipped weapon and armor from the player
- make equipped slots clickable
- export new unequip functions
- test unequipping starting gear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847b459b4b48327abb465d2181cbbba