### PR TITLE
Lower item enhancement bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can now cultivate monsters for equipment. Bury a defeated foe on a farm tile
 
 ### Equipment Enhancement
 
-Gear can be leveled up using materials like **iron** and **bone**. Each enhancement level increases all of an item's stats by **50%**. Press the **강화** button beside an item in your inventory to spend the materials and apply the upgrade. Players now begin the game with **100** iron and **100** bone so you can enhance equipment right away.
+Gear can be leveled up using materials like **iron** and **bone**. Each enhancement level increases all of an item's stats by **5%**. Press the **강화** button beside an item in your inventory to spend the materials and apply the upgrade. Players now begin the game with **100** iron and **100** bone so you can enhance equipment right away.
 
 ### Special Tiles
 

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3513,7 +3513,7 @@ function killMonster(monster) {
         function applyEnhancement(item) {
             if (!item.baseStats) return;
             for (const stat in item.baseStats) {
-                item[stat] = item.baseStats[stat] * Math.pow(1.5, item.enhanceLevel);
+                item[stat] = item.baseStats[stat] * Math.pow(1.05, item.enhanceLevel);
             }
         }
 

--- a/tests/enhanceItem.test.js
+++ b/tests/enhanceItem.test.js
@@ -19,7 +19,7 @@ async function run() {
     console.error('enhance level not incremented');
     process.exit(1);
   }
-  if (sword.attack !== sword.baseStats.attack * 1.5) {
+  if (sword.attack !== sword.baseStats.attack * 1.05) {
     console.error('stats not increased');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- tune equipment upgrade scaling from 50% to 5%
- update docs about enhancement bonus
- adjust enhance item test to new scaling

## Testing
- `npm test` *(fails: affinity.test.js, statusEffects.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847b67aa0048327b43d27a6eba07128