### PR TITLE
Add grave tiles with challenge event

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Dungeon floors contain several interactive tiles:
 - **Trees** provide plenty of **wood**.
 - **Bone Piles** yield lots of **bone**.
 - **Temples** come in three colors and either fully heal the party, restore fullness or raise affinity by 10. Each temple disappears after use.
+- **Graves** present a risky challenge. Accepting it spawns monsters but rewards high level items, materials and gold.
 
 ## Development
 

--- a/tests/graveChallenge.test.js
+++ b/tests/graveChallenge.test.js
@@ -1,0 +1,52 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame({ confirmReturn: true });
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { movePlayer, gameState } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.items = [];
+  gameState.monsters = [];
+  gameState.materials = { wood: 0, iron: 0, bone: 0 };
+  gameState.player.gold = 0;
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+
+  gameState.dungeon[1][2] = 'grave';
+
+  movePlayer(1, 0);
+
+  if (gameState.dungeon[1][2] !== 'empty') {
+    console.error('grave not cleared');
+    process.exit(1);
+  }
+  if (gameState.items.length < 2) {
+    console.error('items not dropped');
+    process.exit(1);
+  }
+  if (gameState.monsters.length === 0) {
+    console.error('monsters not spawned');
+    process.exit(1);
+  }
+  if (gameState.player.gold <= 0) {
+    console.error('gold not awarded');
+    process.exit(1);
+  }
+  if (gameState.materials.wood <= 0 || gameState.materials.iron <= 0 || gameState.materials.bone <= 0) {
+    console.error('materials not gained');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- generate `grave` tiles in new dungeon floors
- display graves with a 🪦 emoji
- implement player interaction when stepping on a grave
- document the grave tile
- add tests for the grave challenge feature

## Testing
- `npm install`
- `npm test` *(fails: RangeError in nova.test.js)*
- `node tests/graveChallenge.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6847bb6f65b48327b9e693fe1d10da44