### PR TITLE
Add sell confirmation

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1482,7 +1482,7 @@ const MERCENARY_NAMES = [
                 sellBtn.className = 'sell-button';
                 sellBtn.onclick = (e) => {
                     e.stopPropagation();
-                    sellItem(item);
+                    confirmAndSell(item);
                 };
                 div.onclick = () => handleItemClick(item);
                 div.appendChild(sellBtn);
@@ -3579,6 +3579,11 @@ function killMonster(monster) {
                 updateInventoryDisplay();
                 updateStats();
             }
+        }
+
+        function confirmAndSell(item) {
+            if (typeof confirm === 'function' && !confirm(`${item.name}을(를) 판매하시겠습니까?`)) return;
+            sellItem(item);
         }
 
         function getEnhanceCost(level) {
@@ -5781,7 +5786,7 @@ loadGame, meleeAttackAction, monsterAttack, movePlayer, nextFloor,
 processMercenaryTurn, processProjectiles, processTurn, purifyTarget, 
 rangedAction, recallMercenaries, recruitHatchedSuperior, handleHatchedMonsterClick,
 removeEggFromIncubator, renderDungeon, reviveMercenary, reviveMonsterCorpse,
-rollDice, saveGame, sellItem, enhanceItem, setMercenaryLevel, setMonsterLevel, setChampionLevel,
+rollDice, saveGame, sellItem, confirmAndSell, enhanceItem, setMercenaryLevel, setMonsterLevel, setChampionLevel,
 showChampionDetails, showItemTargetPanel, showMercenaryDetails,
 showMonsterDetails, showShop, showSkillDamage, showAuraDetails, skill1Action, skill2Action,
 spawnMercenaryNearPlayer, startGame, swapActiveAndStandby, tryApplyStatus,

--- a/tests/confirmAndSell.test.js
+++ b/tests/confirmAndSell.test.js
@@ -1,0 +1,35 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+  const { createItem, addToInventory, confirmAndSell, gameState } = win;
+
+  gameState.player.inventory = [];
+
+  const item1 = createItem('healthPotion', 0, 0);
+  addToInventory(item1);
+  win.confirm = () => false;
+  confirmAndSell(item1);
+  if (gameState.player.inventory.length !== 1) {
+    console.error('item sold despite cancel');
+    process.exit(1);
+  }
+
+  const item2 = createItem('healthPotion', 0, 0);
+  addToInventory(item2);
+  win.confirm = () => true;
+  confirmAndSell(item2);
+  if (gameState.player.inventory.length !== 1) {
+    console.error('item not sold after confirm');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add `confirmAndSell` helper
- use `confirmAndSell` in inventory UI
- export the new helper
- test confirm behavior on selling items

## Testing
- `node runTests.js` *(fails: affinity.test.js, nova.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847bb6b90fc8327860123843a6af023