### PR TITLE
Enable homing behavior for player projectiles

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5244,7 +5244,17 @@ function processTurn() {
 
             const dx = Math.sign(target.x - gameState.player.x);
             const dy = Math.sign(target.y - gameState.player.y);
-            gameState.projectiles.push({ x: gameState.player.x, y: gameState.player.y, dx, dy, rangeLeft: dist, icon: '➡️', element: null });
+            gameState.projectiles.push({
+                x: gameState.player.x,
+                y: gameState.player.y,
+                dx,
+                dy,
+                rangeLeft: dist,
+                icon: '➡️',
+                element: null,
+                homing: true,
+                target
+            });
             processTurn();
         }
 
@@ -5489,7 +5499,24 @@ function processTurn() {
             const dx = Math.sign(target.x - gameState.player.x);
             const dy = Math.sign(target.y - gameState.player.y);
             gameState.player.mana -= manaCost;
-            gameState.projectiles.push({ x: gameState.player.x, y: gameState.player.y, dx, dy, rangeLeft: dist, icon: skill.icon, damageDice: skill.damageDice, magic: skill.magic, skill: skillKey, element: skill.element, level });
+            const proj = {
+                x: gameState.player.x,
+                y: gameState.player.y,
+                dx,
+                dy,
+                rangeLeft: dist,
+                icon: skill.icon,
+                damageDice: skill.damageDice,
+                magic: skill.magic,
+                skill: skillKey,
+                element: skill.element,
+                level
+            };
+            if (skillKey === 'Fireball' || skillKey === 'Iceball') {
+                proj.homing = true;
+                proj.target = target;
+            }
+            gameState.projectiles.push(proj);
             processTurn();
         }
 

--- a/tests/playerHomingProjectiles.test.js
+++ b/tests/playerHomingProjectiles.test.js
@@ -1,0 +1,74 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    gameState,
+    assignSkill,
+    skill1Action,
+    rangedAction,
+    createMonster,
+    processProjectiles,
+    getDistance
+  } = win;
+
+  const size = 10;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.dungeon[1][1] = 'empty';
+
+  const monster = createMonster('ZOMBIE', gameState.player.x + 3, gameState.player.y);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  // Fireball homing
+  gameState.player.skills.push('Fireball');
+  assignSkill(1, 'Fireball');
+  skill1Action();
+  if (gameState.projectiles.length !== 1 || !gameState.projectiles[0].homing || gameState.projectiles[0].target !== monster) {
+    console.error('fireball not homing');
+    process.exit(1);
+  }
+  const prevDist = getDistance(gameState.projectiles[0].x, gameState.projectiles[0].y, monster.x, monster.y);
+  processProjectiles();
+  const newDist = getDistance(gameState.projectiles[0].x, gameState.projectiles[0].y, monster.x, monster.y);
+  if (newDist >= prevDist) {
+    console.error('fireball did not move toward target');
+    process.exit(1);
+  }
+
+  // reset
+  gameState.projectiles = [];
+
+  // Iceball homing
+  gameState.player.skills.push('Iceball');
+  assignSkill(1, 'Iceball');
+  skill1Action();
+  if (gameState.projectiles.length !== 1 || !gameState.projectiles[0].homing || gameState.projectiles[0].target !== monster) {
+    console.error('iceball not homing');
+    process.exit(1);
+  }
+
+  gameState.projectiles = [];
+
+  // Ranged attack homing
+  rangedAction();
+  if (gameState.projectiles.length !== 1 || !gameState.projectiles[0].homing || gameState.projectiles[0].target !== monster) {
+    console.error('ranged attack not homing');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- make ranged attack projectiles follow their target
- enable homing on Fireball and Iceball projectiles
- add regression tests for player homing projectiles

## Testing
- `npm test` *(fails: affinity.test.js, nova.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847bb93f5d08327a0a1b0993a8b8192