### PR TITLE
Implement player stat point allocation

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,11 +792,12 @@
                 <h2>🛡️ 플레이어 정보</h2>
                 <div>📊 레벨: <span id="level">1</span></div>
                 <div>📚 스킬포인트: <span id="skillPoints">0</span></div>
-                <div>💪 힘: <span id="strengthStat">5</span></div>
-                <div>🏃 민첩: <span id="agilityStat">5</span></div>
-                <div>🛡 체력: <span id="enduranceStat">10</span></div>
-                <div>🔮 집중: <span id="focusStat">5</span></div>
-                <div>📖 지능: <span id="intelligenceStat">0</span></div>
+                <div>✨ 스탯포인트: <span id="statPoints">0</span></div>
+                <div>💪 힘: <span id="strengthStat" onclick="allocateStat('strength')">5</span></div>
+                <div>🏃 민첩: <span id="agilityStat" onclick="allocateStat('agility')">5</span></div>
+                <div>🛡 체력: <span id="enduranceStat" onclick="allocateStat('endurance')">10</span></div>
+                <div>🔮 집중: <span id="focusStat" onclick="allocateStat('focus')">5</span></div>
+                <div>📖 지능: <span id="intelligenceStat" onclick="allocateStat('intelligence')">0</span></div>
                 <div>❤️ 체력: <span id="health">20</span>/<span id="maxHealth">20</span></div>
                 <div>🔋 마나: <span id="mana">10</span>/<span id="maxMana">10</span></div>
                 <div class="health-bar-container">

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2197,6 +2197,8 @@ const MERCENARY_NAMES = [
         function updateStats() {
             document.getElementById('level').textContent = formatNumber(gameState.player.level);
             document.getElementById('skillPoints').textContent = formatNumber(gameState.player.skillPoints);
+            const spEl = document.getElementById('statPoints');
+            if (spEl) spEl.textContent = formatNumber(gameState.player.statPoints);
             document.getElementById('strengthStat').textContent = formatNumber(gameState.player.strength);
             document.getElementById('agilityStat').textContent = formatNumber(gameState.player.agility);
             document.getElementById('enduranceStat').textContent = formatNumber(gameState.player.endurance);
@@ -2933,6 +2935,7 @@ function killMonster(monster) {
                 gameState.player.level += 1;
 
                 gameState.player.skillPoints += 1;
+                gameState.player.statPoints = (gameState.player.statPoints || 0) + 5;
 
                 gameState.player.endurance += 2;
                 gameState.player.strength += 1;
@@ -2946,6 +2949,14 @@ function killMonster(monster) {
                 updateStats();
                 updateSkillDisplay();
             }
+        }
+
+        function allocateStat(stat) {
+            if (gameState.player.statPoints <= 0) return;
+            if (!['strength','agility','endurance','focus','intelligence'].includes(stat)) return;
+            gameState.player[stat] += 1;
+            gameState.player.statPoints -= 1;
+            updateStats();
         }
 
         function checkMercenaryLevelUp(mercenary) {
@@ -5513,6 +5524,9 @@ function processTurn() {
             const saved = JSON.parse(data);
             delete saved.mercenaries;
             Object.assign(gameState, saved);
+            if (saved.player.statPoints === undefined) {
+                gameState.player.statPoints = 0;
+            }
             if (saved.activeMercenaries) gameState.activeMercenaries = saved.activeMercenaries;
             else if (saved.mercenaries) gameState.activeMercenaries = saved.mercenaries;
             if (saved.standbyMercenaries) gameState.standbyMercenaries = saved.standbyMercenaries;
@@ -6037,6 +6051,7 @@ function processTurn() {
             gameState.player.job = null;
             const allSkills = Object.keys(SKILL_DEFS);
             gameState.player.skillPoints = 0;
+            gameState.player.statPoints = 0;
             allSkills.forEach(s => {
                 if (!gameState.player.skills.includes(s)) {
                     gameState.player.skills.push(s);
@@ -6166,7 +6181,7 @@ updateFogOfWar, updateIncubatorDisplay,
 updateInventoryDisplay, updateMaterialsDisplay, updateMercenaryDisplay,
 updateShopDisplay, updateSkillDisplay, updateStats, updateTurnEffects,
 upgradeMercenarySkill, upgradeMonsterSkill, useItem, useItemOnTarget, useSkill, removeMercenary,
-dismiss, sacrifice
+    dismiss, sacrifice, allocateStat
 };
 Object.assign(window, exportsObj, {SKILL_DEFS, MERCENARY_SKILLS, MONSTER_SKILLS, MONSTER_SKILL_SETS, MONSTER_TRAITS, MONSTER_TRAIT_SETS, PREFIXES, SUFFIXES});
 

--- a/src/state.js
+++ b/src/state.js
@@ -56,6 +56,7 @@
       gold: 1000,
       inventory: [],
       skillPoints: 0,
+      statPoints: 0,
       skillLevels: {},
       skills: [],
       assignedSkills: {1: null, 2: null},

--- a/tests/playerStatPoints.test.js
+++ b/tests/playerStatPoints.test.js
@@ -1,0 +1,22 @@
+const { loadGame } = require('./helpers');
+const assert = require('assert');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateSkillDisplay = () => {};
+  win.addMessage = () => {};
+  const { gameState, checkLevelUp, allocateStat } = win;
+
+  gameState.player.exp = gameState.player.expNeeded;
+  const before = gameState.player.statPoints;
+  checkLevelUp();
+  assert.strictEqual(gameState.player.statPoints, before + 5, 'stat points not gained');
+
+  const beforeStr = gameState.player.strength;
+  allocateStat('strength');
+  assert.strictEqual(gameState.player.strength, beforeStr + 1, 'stat not increased');
+  assert.strictEqual(gameState.player.statPoints, before + 4, 'stat points not spent');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add `statPoints` field to player state and display it in stats
- award 5 stat points on player level-up
- implement `allocateStat` function to spend stat points
- show stat points in the UI and enable clicking stats to spend points
- reset stat points when starting a new game
- include test for stat point system

## Testing
- `npm install`
- `node runTests.js` *(fails: "revived monster affinity incorrect" in affinity.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847c513490c8327994339b42d44d312