### PR TITLE
Use energy-based loop in affinity test

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2355,7 +2355,8 @@ const MERCENARY_NAMES = [
                 statusEffect: data.statusEffect,
                 lootChance: 0.3,
                 fullness: 75,
-                hasActed: false
+                hasActed: false,
+                energy: 0
             };
             setMonsterLevel(monster, level);
             monster.skillLevels = {};
@@ -2629,6 +2630,7 @@ function killMonster(monster) {
                 affinity: 30,
                 fullness: 75,
                 hasActed: false,
+                energy: 0,
                 equipped: { weapon: null, armor: null, accessory1: null, accessory2: null },
                 range: monster.range,
                 special: monster.special,
@@ -3506,6 +3508,7 @@ function killMonster(monster) {
                 })(),
                 alive: true,
                 hasActed: false,
+                energy: 0,
                 affinity: 50,
                 fullness: 75,
                 equipped: {
@@ -4894,6 +4897,19 @@ function processTurn() {
             updateIncubatorDisplay();
         }
 
+        function advanceGameLoop() {
+            if (!gameState.gameRunning) return;
+            const playerEnergy = gameState.player.energy || 0;
+            const mercHasEnergy = gameState.activeMercenaries.some(m => (m.energy || 0) >= 100);
+            const monsterHasEnergy = gameState.monsters.some(m => (m.energy || 0) >= 100);
+            if (playerEnergy >= 100 || mercHasEnergy || monsterHasEnergy) {
+                processTurn();
+                gameState.player.energy = Math.max(0, playerEnergy - 100);
+                gameState.activeMercenaries.forEach(m => { m.energy = Math.max(0, (m.energy || 0) - 100); });
+                gameState.monsters.forEach(m => { m.energy = Math.max(0, (m.energy || 0) - 100); });
+            }
+        }
+
         // 용병 AI (개선됨 - 장비 보너스 적용, 안전성 체크 추가)
         function processMercenaryTurn(mercenary) {
             if (!mercenary.alive || mercenary.hasActed) return;
@@ -6140,7 +6156,7 @@ function processTurn() {
             }
         });
 const exportsObj = {
-gameState, addMessage, addToInventory, advanceIncubators, 
+gameState, addMessage, addToInventory, advanceIncubators, advanceGameLoop,
 applyStatusEffects, assignSkill, autoMoveStep, averageDice, buildAttackDetail, 
 buyShopItem, checkLevelUp, checkMercenaryLevelUp, checkMonsterLevelUp, 
 convertMonsterToMercenary, craftItem, createChampion, createEliteMonster, 

--- a/src/state.js
+++ b/src/state.js
@@ -18,6 +18,7 @@
       baseDefense: 0,
       maxHealth: 20,
       health: 20,
+      energy: 0,
       maxMana: 10,
       mana: 10,
       healthRegen: 0.3,

--- a/tests/affinity.test.js
+++ b/tests/affinity.test.js
@@ -16,7 +16,7 @@ async function run() {
     killMonster,
     reviveMonsterCorpse,
     monsterAttack,
-    processTurn,
+    advanceGameLoop,
     showMercenaryDetails,
     gameState
   } = win;
@@ -40,7 +40,8 @@ async function run() {
     process.exit(1);
   }
   const before = merc.affinity;
-  processTurn();
+  gameState.player.energy = 100;
+  advanceGameLoop();
   if (merc.affinity <= before) {
     console.error('affinity did not increase');
     process.exit(1);
@@ -68,6 +69,8 @@ async function run() {
   const killer1 = createMonster('ZOMBIE', merc.x + 1, merc.y, 1);
   killer1.attack = 999;
   gameState.monsters.push(killer1);
+  win.Math.random = () => 0;
+  win.rollDice = () => 20;
   const beforeDeath = merc.affinity;
   monsterAttack(killer1);
   if (merc.affinity !== beforeDeath - 5) {


### PR DESCRIPTION
## Summary
- add energy fields to game state actors
- implement `advanceGameLoop` and export it
- update affinity test to use the new helper and deterministic attack

## Testing
- `npm test` *(fails: mercenarySkillUpgrade.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6847c4c0e70c8327b3230407695fa304