### PR TITLE
Implement map system with altar activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,10 @@
             color: #e8f5e9;
             box-shadow: 0 0 6px rgba(76, 175, 80, 0.5);
         }
+        .map_altar {
+            background: radial-gradient(circle, #FFD54F, #FFB300);
+            color: #fff;
+        }
         .projectile {
             background: radial-gradient(circle, #ff9800, #e65100);
             color: white;

--- a/src/state.js
+++ b/src/state.js
@@ -94,7 +94,9 @@
     turn: 0,
     incubators: [null, null],
     hatchedSuperiors: [],
-    gameRunning: true
+    gameRunning: true,
+    isInMap: false,
+    preMapState: null
   };
   global.gameState = gameState;
   global.MONSTER_VISION = MONSTER_VISION;


### PR DESCRIPTION
## Summary
- add `MAP` item type and simple map items
- support map-specific prefixes and suffixes
- allow entering/exiting map dungeons via a map altar
- spawn map altar every 5 floors and update dungeon generation to read map data
- render map altar tile
- extend game state with map fields

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6847c81ee9cc832799c7a46a991f8069