### PR TITLE
Adjust monster speed via map modifiers

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3173,6 +3173,7 @@ function killMonster(monster) {
                 } while (gameState.dungeon[y][x] !== 'empty' || (x === 1 && y === 1));
                 const type = monsterTypes[Math.floor(Math.random() * (monsterTypes.length - 1))];
                 const monster = createMonster(type, x, y, gameState.floor);
+                monster.speed = (monster.speed || 0) + (mapModifiers.monsterSpeedBonus || 0);
                 gameState.monsters.push(monster);
                 gameState.dungeon[y][x] = 'monster';
             }
@@ -3190,6 +3191,7 @@ function killMonster(monster) {
             if (gameState.dungeon[cy][cx] === 'empty') {
                 const ct = champTypes[Math.floor(Math.random() * champTypes.length)];
                 const champ = createChampion(ct, cx, cy, gameState.floor);
+                champ.speed = (champ.speed || 0) + (mapModifiers.monsterSpeedBonus || 0);
                 gameState.monsters.push(champ);
                 gameState.dungeon[cy][cx] = 'monster';
             }
@@ -3202,6 +3204,7 @@ function killMonster(monster) {
             } while (gameState.dungeon[ey][ex] !== 'empty');
             const eType = monsterTypes[Math.floor(Math.random() * monsterTypes.length)];
             const elite = createEliteMonster(eType, ex, ey, gameState.floor);
+            elite.speed = (elite.speed || 0) + (mapModifiers.monsterSpeedBonus || 0);
             gameState.monsters.push(elite);
             gameState.dungeon[ey][ex] = 'monster';
             const around = 2 + Math.floor(Math.random() * 4);
@@ -3210,6 +3213,7 @@ function killMonster(monster) {
                 if (gameState.dungeon[pos.y][pos.x] !== 'empty') continue;
                 const t = monsterTypes[Math.floor(Math.random() * monsterTypes.length)];
                 const m = createMonster(t, pos.x, pos.y, gameState.floor);
+                m.speed = (m.speed || 0) + (mapModifiers.monsterSpeedBonus || 0);
                 gameState.monsters.push(m);
                 gameState.dungeon[pos.y][pos.x] = 'monster';
             }

--- a/src/state.js
+++ b/src/state.js
@@ -97,11 +97,13 @@
     hatchedSuperiors: [],
     gameRunning: true
   };
+  const mapModifiers = { monsterSpeedBonus: 0 };
   global.gameState = gameState;
+  global.mapModifiers = mapModifiers;
   global.MONSTER_VISION = MONSTER_VISION;
   global.FOG_RADIUS = FOG_RADIUS;
   global.MERCENARY_TRIGGER_DISTANCE = MERCENARY_TRIGGER_DISTANCE;
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, MERCENARY_TRIGGER_DISTANCE };
+    module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, MERCENARY_TRIGGER_DISTANCE, mapModifiers };
   }
 })(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- initialize `mapModifiers` in game state
- apply `mapModifiers.monsterSpeedBonus` to every spawned monster

## Testing
- `npm test` *(fails: fire nova incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_6847cd7183d48327908929fecf6c7e44