### PR TITLE
Implement map item modifier system

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -95,6 +95,7 @@
     turn: 0,
     incubators: [null, null],
     hatchedSuperiors: [],
+    currentMapModifiers: null,
     gameRunning: true
   };
   global.gameState = gameState;


### PR DESCRIPTION
## Summary
- add `MAP` to item types and define example map items
- create dedicated `MAP_PREFIXES` and `MAP_SUFFIXES`
- roll map affixes in `createItem`
- update `generateDungeon` to accept map data and apply modifiers
- adjust `killMonster` for loot/gold modifiers
- expose new constants and store active map modifiers in state

## Testing
- `npm install`
- `npm test` *(fails: TypeError: advanceGameLoop is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6847d4497efc83279f88f51f7da21bc8