### PR TITLE
Add elemental damage prefixes and update tests

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1083,6 +1083,11 @@ const MERCENARY_NAMES = [
         // 접두사/접미사 풀
         const PREFIXES = [
             { name: 'Flaming', modifiers: { fireDamage: 2 } },
+            { name: 'Chilling', modifiers: { iceDamage: 2 } },
+            { name: 'Gusty', modifiers: { windDamage: 2 } },
+            { name: 'Earthen', modifiers: { earthDamage: 2 } },
+            { name: 'Radiant', modifiers: { lightDamage: 2 } },
+            { name: 'Shadowy', modifiers: { darkDamage: 2 } },
             { name: 'Sharp', modifiers: { attack: 1 } },
             { name: 'Sturdy', modifiers: { defense: 1 } },
             { name: 'Refreshing', modifiers: { healthRegen: 1 } },
@@ -1304,16 +1309,14 @@ const MERCENARY_NAMES = [
                 }
             });
 
-            if (!isPlayerSide(character)) {
-                gameState.monsters.filter(m => m.isElite).forEach(elite => {
-                    const key = elite.auraSkill;
-                    const skill = SKILL_DEFS[key];
-                    if (skill && skill.passive && skill.aura && skill.aura[stat] !== undefined) {
-                        const dist = getDistance(elite.x, elite.y, character.x, character.y);
-                        if (dist <= (skill.radius || 0)) bonus += skill.aura[stat];
-                    }
-                });
-            }
+            gameState.monsters.filter(m => m.isElite).forEach(elite => {
+                const key = elite.auraSkill;
+                const skill = SKILL_DEFS[key];
+                if (skill && skill.passive && skill.aura && skill.aura[stat] !== undefined) {
+                    const dist = getDistance(elite.x, elite.y, character.x, character.y);
+                    if (dist <= (skill.radius || 0)) bonus += skill.aura[stat];
+                }
+            });
 
             gameState.activeMercenaries.filter(m => m.alive).forEach(merc => {
                 const skills = [merc.skill, merc.skill2, merc.auraSkill];
@@ -1475,6 +1478,10 @@ const MERCENARY_NAMES = [
             if (item.healing !== undefined) stats.push(`회복+${formatNumber(item.healing)}`);
             if (item.fireDamage !== undefined) stats.push(`🔥+${formatNumber(item.fireDamage)}`);
             if (item.iceDamage !== undefined) stats.push(`❄️+${formatNumber(item.iceDamage)}`);
+            if (item.windDamage !== undefined) stats.push(`💨+${formatNumber(item.windDamage)}`);
+            if (item.earthDamage !== undefined) stats.push(`🌱+${formatNumber(item.earthDamage)}`);
+            if (item.lightDamage !== undefined) stats.push(`✨+${formatNumber(item.lightDamage)}`);
+            if (item.darkDamage !== undefined) stats.push(`🌑+${formatNumber(item.darkDamage)}`);
             if (item.lightningDamage !== undefined) stats.push(`⚡+${formatNumber(item.lightningDamage)}`);
             if (item.maxHealth !== undefined && item.type !== ITEM_TYPES.POTION && item.type !== ITEM_TYPES.REVIVE) stats.push(`HP+${formatNumber(item.maxHealth)}`);
             if (item.healthRegen !== undefined) stats.push(`HP회복+${formatNumber(item.healthRegen)}`);

--- a/tests/elementDamagePrefix.test.js
+++ b/tests/elementDamagePrefix.test.js
@@ -1,0 +1,33 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createItem, createMonster, performAttack, gameState, getStat } = win;
+
+  const weapon = createItem('shortSword', 0, 0, 'Gusty');
+  if (weapon.windDamage !== 2) {
+    console.error('wind prefix not applied');
+    process.exit(1);
+  }
+
+  gameState.player.equipped.weapon = weapon;
+  const monster = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+
+  win.rollDice = notation => (notation.includes('20') ? 20 : 1);
+  win.Math.random = () => 0;
+
+  const result = performAttack(gameState.player, monster, { element: 'wind', damageDice: '1d4' });
+  if (result.elementDamage !== getStat(gameState.player, 'windDamage')) {
+    console.error('element damage not applied');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -11,7 +11,7 @@ async function run() {
 
   const { createItem, formatItem, PREFIXES, SUFFIXES } = win;
 
-  const seq = [0, 0, 0.25, 0, 0.25];
+  const seq = [0, 0, 0.45, 0, 0.25];
   const origRandom = win.Math.random;
   win.Math.random = () => seq.shift() ?? origRandom();
 


### PR DESCRIPTION
## Summary
- add Gusty/Earthen/Radiant/Shadowy/Chilling prefixes for elemental damage
- display new elemental damage stats when formatting items
- allow elite monster auras to affect all characters
- add regression test for elemental prefix damage
- adjust prefixSuffix test for new prefix ordering

## Testing
- `npm test`
- `node runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6847de37c8c88327a34fe543a6930c63