### PR TITLE
Prevent monsters without mana from using skills

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -930,11 +930,11 @@ const MERCENARY_NAMES = [
 
 
         const MONSTER_SKILLS = {
-            RottingBite: { name: 'Rotting Bite', icon: '🧟', range: 1, damageDice: '1d6', melee: true, status: 'poison' },
-            PowerStrike: { name: 'Power Strike', icon: '💥', range: 1, damageDice: '1d8', melee: true },
-            ShadowBolt: { name: 'Shadow Bolt', icon: '🌑', range: 3, damageDice: '1d6', magic: true, element: 'dark' },
-            PoisonCloud: { name: 'Poison Cloud', icon: '☣️', radius: 2, damageDice: '1d4', magic: true, status: 'poison' },
-            FireBreath: { name: 'Fire Breath', icon: '🔥', radius: 2, magic: true, element: 'fire', damageDice: '1d6', status: 'burn' }
+            RottingBite: { name: 'Rotting Bite', icon: '🧟', range: 1, damageDice: '1d6', melee: true, status: 'poison', manaCost: 2 },
+            PowerStrike: { name: 'Power Strike', icon: '💥', range: 1, damageDice: '1d8', melee: true, manaCost: 2 },
+            ShadowBolt: { name: 'Shadow Bolt', icon: '🌑', range: 3, damageDice: '1d6', magic: true, element: 'dark', manaCost: 2 },
+            PoisonCloud: { name: 'Poison Cloud', icon: '☣️', radius: 2, damageDice: '1d4', magic: true, status: 'poison', manaCost: 2 },
+            FireBreath: { name: 'Fire Breath', icon: '🔥', radius: 2, magic: true, element: 'fire', damageDice: '1d6', status: 'burn', manaCost: 2 }
         };
 
 


### PR DESCRIPTION
## Summary
- add `manaCost` to base monster skills so that monsters with no MP can't spam abilities

## Testing
- `npm install`
- `npm test` *(fails: aura bonus not applied)*

------
https://chatgpt.com/codex/tasks/task_e_6847e56b57cc83278a59b9ff3d10f51c