### PR TITLE
Spawn recipe scrolls near player

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Incubators let you hatch monster eggs into powerful allies. Place an egg from yo
 ### Loot
 
 Recipe scrolls may drop from monsters or appear in dungeons. Picking one up automatically adds the recipe to your known list. Duplicate scrolls are ignored once learned.
+When starting a new game, a handful of random recipe scrolls also appear near the player so you can begin cooking right away.
 
 ### Monster Farming
 

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -6307,6 +6307,19 @@ function processTurn() {
             updateShopDisplay();
         }
 
+        function spawnStartingRecipes(count = 3) {
+            const unknown = Object.keys(RECIPES).filter(r => !gameState.knownRecipes.includes(r));
+            for (let i = 0; i < count && unknown.length; i++) {
+                const idx = Math.floor(Math.random() * unknown.length);
+                const key = unknown.splice(idx, 1)[0];
+                const pos = findAdjacentEmpty(gameState.player.x, gameState.player.y);
+                if (pos.x === gameState.player.x && pos.y === gameState.player.y) break;
+                const scroll = createRecipeScroll(key, pos.x, pos.y);
+                gameState.items.push(scroll);
+                gameState.dungeon[pos.y][pos.x] = 'item';
+            }
+        }
+
         function startGame() {
             gameState.player.job = null;
             const allSkills = Object.keys(SKILL_DEFS);
@@ -6332,6 +6345,7 @@ function processTurn() {
             for (let i = 0; i < 5; i++) {
                 gameState.player.inventory.push(createItem('smallExpScroll', 0, 0));
             }
+            spawnStartingRecipes();
             updateInventoryDisplay();
             updateSkillDisplay();
             updateIncubatorDisplay();
@@ -6443,7 +6457,7 @@ removeEggFromIncubator, renderDungeon, reviveMercenary, reviveMonsterCorpse,
  rollDice, saveGame, sellItem, confirmAndSell, enhanceItem, disassembleItem, setMercenaryLevel, setMonsterLevel, setChampionLevel,
 showChampionDetails, showItemDetailPanel, showItemTargetPanel, showMercenaryDetails,
 showMonsterDetails, showShop, showSkillDamage, showAuraDetails, skill1Action, skill2Action,
-spawnMercenaryNearPlayer, startGame, swapActiveAndStandby, tryApplyStatus,
+spawnMercenaryNearPlayer, spawnStartingRecipes, startGame, swapActiveAndStandby, tryApplyStatus,
 unequipAccessory, unequipWeapon, unequipArmor, unequipItemFromMercenary, updateActionButtons, updateCamera,
 updateFogOfWar, updateIncubatorDisplay,
 updateInventoryDisplay, updateMaterialsDisplay, updateMercenaryDisplay,


### PR DESCRIPTION
## Summary
- spawn several random recipe scrolls next to the player on a new game
- document the new early-game recipe drops

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6847ed5f7b408327b527e9547b63688c