### PR TITLE
Fix test resource loading

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -9,7 +9,6 @@ async function loadGame(options = {}) {
   const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
     runScripts: 'dangerously',
     resources: 'usable',
-    url: 'http://localhost',
     beforeParse(window) {
       window.rollDice = rollDice;
       window.confirm = () => confirmReturn;


### PR DESCRIPTION
## Summary
- remove `url` option from `JSDOM.fromFile` so relative resources load from the filesystem

## Testing
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684809cf3e108327bbff7c1683f99b08