### PR TITLE
Fix wall tile border style and maintain transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             font-size: 14px;
             background-color: #2a2a2a;
             border-radius: 2px;
-            transition: all 0.3s;
+            transition: filter 0.3s;
             position: relative;
             cursor: pointer;
         }

--- a/style.css
+++ b/style.css
@@ -30,4 +30,5 @@
   background-size: cover;
   color: unset;
   font-size: unset;
+  border: 1px solid #000;
 }


### PR DESCRIPTION
## Summary
- restore wall-tile.png from original commit
- apply border for wall tiles via CSS rather than the image
- keep index.html's cell transition on the `filter` property

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_684813a88fcc8327940430e3a0460e8a