### PR TITLE
Add mercenary type CSS and cell background fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,8 @@
             transition: filter 0.3s;
             position: relative;
             cursor: pointer;
+            background-size: cover;
+            background-repeat: no-repeat;
         }
         .wall {
             background: linear-gradient(45deg, #1a1a1a, #2a2a2a);

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3088,6 +3088,9 @@ function killMonster(monster) {
                             const merc = gameState.activeMercenaries.find(m => m.x === x && m.y === y && m.alive);
                             if (merc) {
                                 finalClasses.push('mercenary');
+                                if (merc.type) {
+                                    finalClasses.push(merc.type.toLowerCase());
+                                }
                             } else if (baseCellType === 'monster') {
                                 const m = gameState.monsters.find(mon => mon.x === x && mon.y === y);
                                 if (m) {

--- a/style.css
+++ b/style.css
@@ -47,3 +47,20 @@
   background-position: center, center;
   background-repeat: no-repeat, no-repeat;
 }
+
+/* Individual mercenary sprites */
+.mercenary.warrior {
+  background-image: url("assets/images/warrior.png");
+}
+
+.mercenary.archer {
+  background-image: url("assets/images/archer.png");
+}
+
+.mercenary.healer {
+  background-image: url("assets/images/healer.png");
+}
+
+.mercenary.wizard {
+  background-image: url("assets/images/wizard.png");
+}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -6,9 +6,13 @@ const vm = require('vm');
 
 async function loadGame(options = {}) {
   const { confirmReturn = true } = options;
-  const dom = await JSDOM.fromFile(path.join(__dirname, '..', 'index.html'), {
+  const htmlPath = path.join(__dirname, '..', 'index.html');
+  let html = fs.readFileSync(htmlPath, 'utf8');
+  html = html.replace(/<link rel="stylesheet" href="style.css">/, '');
+  const dom = new JSDOM(html, {
     runScripts: 'dangerously',
     resources: 'usable',
+    url: 'http://localhost',
     beforeParse(window) {
       window.rollDice = rollDice;
       window.confirm = () => confirmReturn;


### PR DESCRIPTION
## Summary
- add specific mercenary classes for warrior, archer, healer and wizard
- append mercenary type to renderDungeon cell classes
- ensure generic cell styling covers backgrounds
- update test helpers to load index HTML without linked CSS

## Testing
- `node runTests.js` *(fails: aura bonus not applied in elite.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68484d303b10832782590a4464cd348b