### PR TITLE
Add monster images and render logic

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -401,7 +401,7 @@ const MERCENARY_NAMES = [
             },
             GOBLIN_ARCHER: {
                 name: '🏹 고블린 궁수',
-                icon: '🏹',
+                icon: '',
                 color: '#6B8E23',
                 baseHealth: 4,
                 baseAttack: 3,
@@ -566,7 +566,7 @@ const MERCENARY_NAMES = [
             },
             SLIME: {
                 name: '🟢 슬라임',
-                icon: '🟢',
+                icon: '',
                 color: '#7FFF00',
                 baseHealth: 5,
                 baseAttack: 2,
@@ -3095,7 +3095,11 @@ function killMonster(monster) {
                             } else if (baseCellType === 'monster') {
                                 const m = gameState.monsters.find(mon => mon.x === x && mon.y === y);
                                 if (m) {
-                                    div.textContent = m.icon;
+                                    const monsterClass = m.type.replace('_', '-').toLowerCase();
+                                    finalClasses.push('monster', monsterClass);
+                                    if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer') {
+                                         div.textContent = m.icon;
+                                    }
                                     if (m.isChampion) finalClasses.push('champion');
                                     else if (m.isElite) finalClasses.push('elite');
                                 }

--- a/style.css
+++ b/style.css
@@ -112,3 +112,30 @@
 .cell.mercenary.wizard {
   background-image: url('../assets/images/wizard.png');
 }
+
+/* --- 신규 몬스터 이미지 스타일 --- */
+
+/* 이미지를 사용하는 모든 몬스터의 기본 스타일 초기화 */
+.cell.monster {
+  background: transparent;
+  color: transparent;
+  box-shadow: none;
+  animation: none;
+}
+
+/* 몬스터가 바닥 타일 위에 있을 때의 스타일 */
+.cell.empty.monster {
+  background-size: contain, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+/* 슬라임 이미지 적용 */
+.cell.empty.monster.slime {
+  background-image: url("assets/images/slime.png"), url("assets/images/floor-tile.png");
+}
+
+/* 고블린 궁수 이미지 적용 */
+.cell.empty.monster.goblin-archer {
+  background-image: url("assets/images/goblin-archer.png"), url("assets/images/floor-tile.png");
+}


### PR DESCRIPTION
## Summary
- style monsters with new slime and goblin-archer sprites
- render monsters with CSS classes for image-based sprites
- remove emoji icons for slime and goblin-archer

## Testing
- `npm test` *(fails: Could not load script via jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68485ddabce48327961c5c7b8dd67303