### PR TITLE
Add goblin sprite support

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -345,7 +345,7 @@ const MERCENARY_NAMES = [
             },
             GOBLIN: {
                 name: '👹 고블린',
-                icon: '👹',
+                icon: '',
                 color: '#32CD32',
                 baseHealth: 4,
                 baseAttack: 2,
@@ -3097,7 +3097,7 @@ function killMonster(monster) {
                                 if (m) {
                                     const monsterClass = m.type.replace('_', '-').toLowerCase();
                                     finalClasses.push('monster', monsterClass);
-                                    if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer') {
+                                    if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer' && monsterClass !== 'goblin') {
                                          div.textContent = m.icon;
                                     }
                                     if (m.isChampion) finalClasses.push('champion');

--- a/style.css
+++ b/style.css
@@ -139,3 +139,8 @@
 .cell.empty.monster.goblin-archer {
   background-image: url("assets/images/goblin-archer.png"), url("assets/images/floor-tile.png");
 }
+
+/* 고블린 이미지 적용 */
+.cell.empty.monster.goblin {
+  background-image: url("assets/images/goblin.png"), url("assets/images/floor-tile.png");
+}


### PR DESCRIPTION
## Summary
- apply goblin sprite styling for dungeon cells
- avoid showing goblin emoji in `renderDungeon`
- clear goblin icon text to use image sprite

## Testing
- `npm install`
- `npm test` *(fails: Could not load script `dice.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68485f21432c8327b4c13612abaab04e