### PR TITLE
Fix monster sprite CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,32 +115,28 @@
 
 /* --- 신규 몬스터 이미지 스타일 --- */
 
-/* 이미지를 사용하는 모든 몬스터의 기본 스타일 초기화 */
+/* 이미지를 사용하는 모든 몬스터의 기본 스타일 및 배경 설정 */
 .cell.monster {
   background: transparent;
   color: transparent;
   box-shadow: none;
   animation: none;
-}
-
-/* 몬스터가 바닥 타일 위에 있을 때의 스타일 */
-.cell.empty.monster {
   background-size: contain, cover;
   background-position: center, center;
   background-repeat: no-repeat, no-repeat;
 }
 
 /* 슬라임 이미지 적용 */
-.cell.empty.monster.slime {
+.cell.monster.slime {
   background-image: url("assets/images/slime.png"), url("assets/images/floor-tile.png");
 }
 
 /* 고블린 궁수 이미지 적용 */
-.cell.empty.monster.goblin-archer {
+.cell.monster.goblin-archer {
   background-image: url("assets/images/goblin-archer.png"), url("assets/images/floor-tile.png");
 }
 
 /* 고블린 이미지 적용 */
-.cell.empty.monster.goblin {
+.cell.monster.goblin {
   background-image: url("assets/images/goblin.png"), url("assets/images/floor-tile.png");
 }


### PR DESCRIPTION
## Summary
- fix CSS selectors for monster sprites
- ensure floor tile backgrounds appear beneath monsters

## Testing
- `npm install`
- `npm test` *(fails: Could not load script "http://localhost/dice.js")*

------
https://chatgpt.com/codex/tasks/task_e_68486005d9a08327a262031135bad6fc