### PR TITLE
Refactor mercenary turn to accept visible monsters list

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5072,7 +5072,7 @@ function processTurn() {
             });
 
             sortedMercenaries.forEach(mercenary => {
-                processMercenaryTurn(mercenary);
+                processMercenaryTurn(mercenary, gameState.monsters);
             });
 
             const occupied = new Set();
@@ -5259,7 +5259,7 @@ function processTurn() {
         }
 
         // 용병 AI (개선됨 - 장비 보너스 적용, 안전성 체크 추가)
-        function processMercenaryTurn(mercenary) {
+        function processMercenaryTurn(mercenary, visibleMonsters = gameState.monsters) {
             if (!mercenary.alive || mercenary.hasActed) return;
             if ((mercenary.paralysis && mercenary.paralysisTurns > 0) || (mercenary.petrify && mercenary.petrifyTurns > 0)) {
                 mercenary.paralysisTurns && mercenary.paralysisTurns--;
@@ -5394,15 +5394,10 @@ function processTurn() {
             let nearestMonster = null;
             let nearestDistance = Infinity;
             
-            gameState.monsters.forEach(monster => {
-                // 몬스터가 시야 밖(fog of war)에 있으면 무시
-                if (gameState.fogOfWar[monster.y] && gameState.fogOfWar[monster.y][monster.x]) {
-                    return;
-                }
-
-                const distance = getDistance(mercenary.x, mercenary.y, monster.x, monster.y);
-                if (distance < nearestDistance && hasLineOfSight(mercenary.x, mercenary.y, monster.x, monster.y)) {
-                    nearestDistance = distance;
+            visibleMonsters.forEach(monster => {
+                const dist = getDistance(mercenary.x, mercenary.y, monster.x, monster.y);
+                if (dist < nearestDistance && hasLineOfSight(mercenary.x, mercenary.y, monster.x, monster.y)) {
+                    nearestDistance = dist;
                     nearestMonster = monster;
                 }
             });

--- a/tests/healSelf.test.js
+++ b/tests/healSelf.test.js
@@ -33,7 +33,7 @@ async function run() {
 
   const origRandom = win.Math.random;
   win.Math.random = () => 0;
-  processMercenaryTurn(healer);
+  processMercenaryTurn(healer, gameState.monsters);
   win.Math.random = origRandom;
 
   if (healer.health <= beforeHealth || healer.mana !== beforeMana - 2) {

--- a/tests/magicScaling.test.js
+++ b/tests/magicScaling.test.js
@@ -65,7 +65,7 @@ async function run() {
   win.rollDice = () => 8;
   const origRandom = win.Math.random;
   win.Math.random = () => 0;
-  processMercenaryTurn(fireCaster);
+  processMercenaryTurn(fireCaster, gameState.monsters);
   win.Math.random = origRandom;
   win.performAttack = origPerform;
 
@@ -94,7 +94,7 @@ async function run() {
   };
   win.rollDice = () => 6;
   win.Math.random = () => 0;
-  processMercenaryTurn(iceCaster);
+  processMercenaryTurn(iceCaster, gameState.monsters);
   win.Math.random = origRandom;
   win.performAttack = origPerform;
 

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -50,7 +50,7 @@ async function run() {
   const origRandom = win.Math.random;
   win.Math.random = () => 0;
 
-  processMercenaryTurn(merc);
+  processMercenaryTurn(merc, gameState.monsters);
 
   win.Math.random = origRandom;
 

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -60,7 +60,7 @@ async function run() {
   const healthBefore = merc.health;
   const origRandom = win.Math.random;
   win.Math.random = () => 0;
-  processMercenaryTurn(merc);
+  processMercenaryTurn(merc, gameState.monsters);
   win.Math.random = origRandom;
   const startMana = Math.min(manaBefore + getStat(merc, 'manaRegen'), getStat(merc, 'maxMana'));
   const manaExpected = startMana - (MERCENARY_SKILLS[skillKey].manaCost + healLevel - 1);


### PR DESCRIPTION
## Summary
- update `processMercenaryTurn` to accept an optional `visibleMonsters` argument
- look for nearest foe in the supplied list
- pass `gameState.monsters` everywhere the function is called
- update tests for the new signature

## Testing
- `npm test` *(fails: `Error: mercenaryFollow.test.js failed with code 1`)*

------
https://chatgpt.com/codex/tasks/task_e_68486b8a5f288327b5e16aec15d3bb91