### PR TITLE
Add resistance enhancement test

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2388,9 +2388,14 @@ const MERCENARY_NAMES = [
             for (const pos of positions) {
                 if (pos.x >= 0 && pos.x < gameState.dungeonSize &&
                     pos.y >= 0 && pos.y < gameState.dungeonSize &&
-                    gameState.dungeon[pos.y] && gameState.dungeon[pos.y][pos.x] === 'empty' &&
+                    gameState.dungeon[pos.y] && ['empty','item'].includes(gameState.dungeon[pos.y][pos.x]) &&
                     !gameState.activeMercenaries.some(m => m.x === pos.x && m.y === pos.y && m.alive) &&
                     !gameState.monsters.some(m => m.x === pos.x && m.y === pos.y)) {
+                    if (gameState.dungeon[pos.y][pos.x] === 'item') {
+                        const idx = gameState.items.findIndex(it => it.x === pos.x && it.y === pos.y);
+                        if (idx !== -1) gameState.items.splice(idx, 1);
+                    }
+                    gameState.dungeon[pos.y][pos.x] = 'empty';
                     mercenary.x = pos.x;
                     mercenary.y = pos.y;
                     return true;
@@ -4123,6 +4128,8 @@ function killMonster(monster) {
             for (const stat in item.baseStats) {
                 if (stat === 'attack' || stat === 'defense') {
                     item[stat] = item.baseStats[stat] + item.enhanceLevel * 1;
+                } else if (stat.endsWith('Resist')) {
+                    item[stat] = item.baseStats[stat] + item.enhanceLevel * 0.025;
                 } else {
                     item[stat] = item.baseStats[stat] + item.enhanceLevel * 0.5;
                 }

--- a/tests/enhanceResistance.test.js
+++ b/tests/enhanceResistance.test.js
@@ -1,0 +1,29 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateMaterialsDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.addMessage = () => {};
+  const { createItem, addToInventory, enhanceItem, gameState } = win;
+
+  const item = createItem('shortSword', 0, 0, 'Poison Resistant');
+  addToInventory(item);
+
+  gameState.materials.iron = 1;
+  gameState.materials.bone = 1;
+
+  enhanceItem(item);
+
+  if (item.enhanceLevel !== 1) {
+    console.error('enhance level not incremented');
+    process.exit(1);
+  }
+  const expected = item.baseStats.poisonResist + 0.025;
+  if (Math.abs(item.poisonResist - expected) > 1e-9) {
+    console.error('resistance stat not increased correctly');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -9,6 +9,7 @@ async function loadGame(options = {}) {
   const htmlPath = path.join(__dirname, '..', 'index.html');
   let html = fs.readFileSync(htmlPath, 'utf8');
   html = html.replace(/<link rel="stylesheet" href="style.css">/, '');
+  html = html.replace('<script src="dice.js"></script>', '');
   const dom = new JSDOM(html, {
     runScripts: 'dangerously',
     resources: 'usable',
@@ -41,6 +42,8 @@ async function loadGame(options = {}) {
     const script = new vm.Script(code, { filename: file });
     script.runInContext(ctx);
   }
+
+  dom.window.generateStars = () => ({ strength: 0, agility: 0, endurance: 0, focus: 0, intelligence: 0 });
 
   return dom.window;
 }


### PR DESCRIPTION
## Summary
- test enhancing items with resistance stats
- adjust enhancement logic for resistances
- allow mercenary spawn on item cells
- make tests deterministic by overriding star generation
- strip dice.js script when loading game

## Testing
- `node runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_68486a68dfb08327b35664326f52e289