### PR TITLE
Update skillName param in tests

### DIFF
--- a/tests/elementDamagePrefix.test.js
+++ b/tests/elementDamagePrefix.test.js
@@ -23,7 +23,7 @@ async function run() {
   win.rollDice = notation => (notation.includes('20') ? 20 : 1);
   win.Math.random = () => 0;
 
-  const result = performAttack(gameState.player, monster, { element: 'wind', damageDice: '1d4' });
+  const result = performAttack(gameState.player, monster, { element: 'wind', damageDice: '1d4' }, 'test');
   if (result.elementDamage !== getStat(gameState.player, 'windDamage')) {
     console.error('element damage not applied');
     process.exit(1);

--- a/tests/magicProjectile.test.js
+++ b/tests/magicProjectile.test.js
@@ -25,9 +25,10 @@ async function run() {
   win.rollDice = () => 10;
 
   let captured;
-  win.performAttack = (attacker, defender, opts) => {
+  const origPerform = win.performAttack;
+  win.performAttack = (attacker, defender, opts, skillName) => {
     captured = opts;
-    return { hit: true, crit: false, baseDamage: 0, elementDamage: 0 };
+    return origPerform(attacker, defender, opts, skillName);
   };
 
   processProjectiles();

--- a/tests/magicScaling.test.js
+++ b/tests/magicScaling.test.js
@@ -58,9 +58,9 @@ async function run() {
 
   let captured = null;
   const origPerform = win.performAttack;
-  win.performAttack = (att, def, opts) => {
+  win.performAttack = (att, def, opts, skillName) => {
     captured = opts;
-    return { hit: true, crit: false, baseDamage: 0, elementDamage: 0 };
+    return origPerform(att, def, opts, skillName);
   };
   win.rollDice = () => 8;
   const origRandom = win.Math.random;
@@ -88,9 +88,9 @@ async function run() {
   gameState.dungeon[monster2.y][monster2.x] = 'monster';
 
   captured = null;
-  win.performAttack = (att, def, opts) => {
+  win.performAttack = (att, def, opts, skillName) => {
     captured = opts;
-    return { hit: true, crit: false, baseDamage: 0, elementDamage: 0 };
+    return origPerform(att, def, opts, skillName);
   };
   win.rollDice = () => 6;
   win.Math.random = () => 0;

--- a/tests/nova.test.js
+++ b/tests/nova.test.js
@@ -35,7 +35,8 @@ async function run() {
   gameState.dungeon[m2.y][m2.x] = 'monster';
 
   let captured = [];
-  win.performAttack = (att, def, opts) => { captured.push(opts); return { hit: true, crit: false, baseDamage: 0, elementDamage: 0 }; };
+  const origPerform = win.performAttack;
+  win.performAttack = (att, def, opts, skillName) => { captured.push(opts); return origPerform(att, def, opts, skillName); };
   win.rollDice = () => 4;
   skill1Action();
 


### PR DESCRIPTION
## Summary
- add placeholder skill name to direct `performAttack` test call
- forward new `skillName` argument when stubbing `performAttack`

## Testing
- `npm test` *(fails: Could not load script `dice.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68486fcd179883278a8910f3fbca99ea