### PR TITLE
Add colored glows for special units

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ stored as crafting materials rather than in your main inventory.
 
 ### Elite Monsters and Auras
 
-Each dungeon floor now contains at least one **elite** monster. Elites boast higher stats and randomly receive an aura skill that benefits nearby allies. When an elite is revived as a mercenary, it keeps this aura skill. Elites appear with a purple glow and the "엘리트" prefix.
+Each dungeon floor now contains at least one **elite** monster. Elites boast higher stats and randomly receive an aura skill that benefits nearby allies. When an elite is revived as a mercenary, it keeps this aura skill. Elites display a red glow and the "엘리트" prefix. Champions glow yellow, and superior monsters glow blue.
 
 #### Superior Rank
 

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2822,6 +2822,9 @@ function killMonster(monster) {
                 type: 'MONSTER',
                 monsterType: monster.type,
                 isMonster: true,
+                isElite: !!monster.isElite,
+                isChampion: !!monster.isChampion,
+                isSuperior: !!monster.isSuperior,
                 name: monster.name,
                 icon: monster.icon,
                 role: monster.special === 'ranged' ? 'ranged' : monster.special === 'magic' ? 'caster' : 'tank',
@@ -3109,6 +3112,9 @@ function killMonster(monster) {
                                     // 일반 용병일 경우 기존 로직대로 type을 사용
                                     finalClasses.push(merc.type.toLowerCase());
                                 }
+                                if (merc.isSuperior) finalClasses.push('superior');
+                                else if (merc.isChampion) finalClasses.push('champion');
+                                else if (merc.isElite) finalClasses.push('elite');
                                 div.textContent = '';
                             } else if (baseCellType === 'monster') {
                                 const m = gameState.monsters.find(mon => mon.x === x && mon.y === y);
@@ -3118,7 +3124,8 @@ function killMonster(monster) {
                                     if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer' && monsterClass !== 'goblin') {
                                          div.textContent = m.icon;
                                     }
-                                    if (m.isChampion) finalClasses.push('champion');
+                                    if (m.isSuperior) finalClasses.push('superior');
+                                    else if (m.isChampion) finalClasses.push('champion');
                                     else if (m.isElite) finalClasses.push('elite');
                                 }
                             } else if (baseCellType === 'item') {

--- a/style.css
+++ b/style.css
@@ -140,3 +140,19 @@
 .cell.monster.goblin {
   background-image: url("assets/images/goblin.png"), url("assets/images/floor-tile.png");
 }
+
+/* ---- Special unit glow effects ---- */
+.cell.elite {
+  box-shadow: 0 0 8px rgba(244, 67, 54, 0.7);
+  animation: monsterPulse 1.5s ease-in-out infinite alternate;
+}
+
+.cell.champion {
+  box-shadow: 0 0 8px rgba(255, 235, 59, 0.7);
+  animation: monsterPulse 1.5s ease-in-out infinite alternate;
+}
+
+.cell.superior {
+  box-shadow: 0 0 8px rgba(33, 150, 243, 0.7);
+  animation: monsterPulse 1.5s ease-in-out infinite alternate;
+}


### PR DESCRIPTION
## Summary
- keep elite/champion/superior status when reviving monsters
- show glow colors in CSS for elite (red), champion (yellow) and superior (blue)
- render glow classes on monsters and revived allies
- document the new glow colors in README

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_684911e940988327be032403fdb6fa11