### PR TITLE
Add inventory filter UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -786,6 +786,15 @@
                     <div class="equipped-slot" id="equipped-accessory2">악세서리2: 없음</div>
                 </div>
                 <h3>📦 보유 아이템</h3>
+                <div id="inventory-filters" style="margin-bottom: 10px; display: flex; flex-wrap: wrap; gap: 5px;">
+                    <button class="inv-filter-btn active" data-filter="all">모두</button>
+                    <button class="inv-filter-btn" data-filter="equipment">장비</button>
+                    <button class="inv-filter-btn" data-filter="recipe">레시피</button>
+                    <button class="inv-filter-btn" data-filter="food">음식</button>
+                    <button class="inv-filter-btn" data-filter="potion">포션</button>
+                    <button class="inv-filter-btn" data-filter="map">지도</button>
+                    <button class="inv-filter-btn" data-filter="etc">기타</button>
+                </div>
                 <div id="inventory-items"></div>
             </div>
             <div class="skills-panel">

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -168,6 +168,15 @@ const ITEM_TYPES = {
             MAP: 'map'
         };
 
+const INVENTORY_CATEGORIES = {
+    equipment: [ITEM_TYPES.WEAPON, ITEM_TYPES.ARMOR, ITEM_TYPES.ACCESSORY],
+    recipe: [ITEM_TYPES.RECIPE_SCROLL],
+    food: [ITEM_TYPES.FOOD],
+    potion: [ITEM_TYPES.POTION, ITEM_TYPES.REVIVE],
+    map: [ITEM_TYPES.MAP],
+    etc: [ITEM_TYPES.EGG, ITEM_TYPES.FERTILIZER, ITEM_TYPES.ESSENCE]
+};
+
         const SHOP_PRICE_MULTIPLIER = 3;
 
 const MERCENARY_NAMES = [
@@ -1828,11 +1837,17 @@ const MERCENARY_NAMES = [
             const container = document.getElementById('inventory-items');
             container.innerHTML = '';
 
+            const currentFilter = gameState.inventoryFilter;
+            let filteredInventory = gameState.player.inventory;
 
+            if (currentFilter !== 'all') {
+                const targetTypes = INVENTORY_CATEGORIES[currentFilter] || [];
+                filteredInventory = gameState.player.inventory.filter(item => targetTypes.includes(item.type));
+            }
 
             // group identical items together so they can be displayed as stacks
             const groups = new Map();
-            for (const item of gameState.player.inventory) {
+            for (const item of filteredInventory) {
                 const key = `${item.key}-${item.prefix || ''}-${item.suffix || ''}-${item.enhanceLevel || 0}`;
                 if (!groups.has(key)) {
                     groups.set(key, { item, count: 0 });
@@ -6722,6 +6737,17 @@ function processTurn() {
                     showMercenaryDetails(gameState.activeMercenaries[idx]);
                 }
             }
+        });
+
+        const filterButtons = document.querySelectorAll('.inv-filter-btn');
+        filterButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                filterButtons.forEach(btn => btn.classList.remove('active'));
+                button.classList.add('active');
+
+                gameState.inventoryFilter = button.dataset.filter;
+                updateInventoryDisplay();
+            });
         });
 const exportsObj = {
 gameState, addMessage, addToInventory, advanceIncubators, advanceGameLoop,

--- a/src/state.js
+++ b/src/state.js
@@ -94,6 +94,7 @@
     camera: { x: 0, y: 0 },
     autoMovePath: null,
     autoMoveActive: false,
+    inventoryFilter: 'all',
     turn: 0,
     incubators: [null, null],
     hatchedSuperiors: [],

--- a/style.css
+++ b/style.css
@@ -156,3 +156,19 @@
   box-shadow: 0 0 8px rgba(33, 150, 243, 0.7);
   animation: monsterPulse 1.5s ease-in-out infinite alternate;
 }
+
+.inv-filter-btn {
+  padding: 4px 8px;
+  border: 1px solid #777;
+  background-color: #444;
+  color: #ddd;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.inv-filter-btn.active {
+  background-color: #6a6a6a;
+  border-color: #aaa;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add inventory filter buttons to inventory section
- track current filter in game state
- implement filter logic in updateInventoryDisplay
- handle filter button click events
- style the filter buttons

## Testing
- `npm test` *(fails: Web Audio API not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684914991d888327a7dcb08a3403b095