### PR TITLE
Implement status effect icon display

### DIFF
--- a/style.css
+++ b/style.css
@@ -172,3 +172,29 @@
   border-color: #aaa;
   font-weight: bold;
 }
+
+/* --- 유닛 효과 아이콘 스타일 --- */
+.buff-container, .status-container {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  font-size: 10px;
+  line-height: 1;
+  gap: 1px;
+}
+
+.buff-container {
+  top: -2px;
+}
+
+.status-container {
+  bottom: -2px;
+}
+
+.effect-icon {
+  text-shadow: 0 0 2px black, 0 0 2px black;
+}


### PR DESCRIPTION
## Summary
- prepare dungeon cells with buff and status icon containers
- style the new buff/status icon overlays
- add helper methods for aura/status icon handling
- render unit effect icons for players, mercenaries, and monsters
- expose helpers through exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849185dcb64832797aea85ef8ab14b2