### PR TITLE
Fix effect icon styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -197,4 +197,5 @@
 
 .effect-icon {
   text-shadow: 0 0 2px black, 0 0 2px black;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- ensure effect icons use white text

## Testing
- `npm test` *(fails: monsterExp.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68492afa6448832781f0dac36549fd13