### PR TITLE
Fix aura side checks

### DIFF
--- a/tests/auraSides.test.js
+++ b/tests/auraSides.test.js
@@ -1,0 +1,33 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { assignSkill, createMonster, getStat, gameState } = win;
+
+  gameState.dungeonSize = 3;
+  gameState.dungeon = Array.from({ length: 3 }, () => Array(3).fill('empty'));
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+
+  const monster = createMonster('GOBLIN', 2, 1, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[1][2] = 'monster';
+
+  assignSkill(1, 'ProtectAura');
+
+  const base = getStat(monster, 'defense');
+  if (getStat(monster, 'defense') !== base) {
+    console.error('player aura affected enemy');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/elite.test.js
+++ b/tests/elite.test.js
@@ -32,15 +32,26 @@ async function run() {
 
   const base = gameState.player.healthRegen;
   const regen = getStat(gameState.player, 'healthRegen');
-  const auraVal = SKILL_DEFS[elite.auraSkill].aura.healthRegen;
-  if (Math.abs(regen - (base + auraVal)) > 0.001) {
-    console.error('aura bonus not applied');
+  if (Math.abs(regen - base) > 0.001) {
+    console.error('enemy aura applied');
     process.exit(1);
   }
 
   const merc = convertMonsterToMercenary(elite);
   if (merc.skill !== elite.auraSkill) {
     console.error('aura skill not kept on revival');
+    process.exit(1);
+  }
+
+  gameState.monsters = [];
+  merc.x = 1;
+  merc.y = 1;
+  gameState.activeMercenaries.push(merc);
+
+  const auraVal = SKILL_DEFS[elite.auraSkill].aura.healthRegen;
+  const regen2 = getStat(gameState.player, 'healthRegen');
+  if (Math.abs(regen2 - (base + auraVal)) > 0.001) {
+    console.error('aura bonus not applied after conversion');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- add `isSameSide` helper to detect allies
- restrict aura bonuses to units on the same side
- update elite aura tests and add new test to ensure cross-side buffs don't apply

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684938d1bbc48327a3afc0d2f78569ed