### PR TITLE
Fix player aura display

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2687,7 +2687,7 @@ const MERCENARY_NAMES = [
         function getActiveAuraIcons(character) {
             const icons = new Set();
             const checkSource = (source) => {
-                if (!source || !source.alive) return;
+                if (!source || (source !== gameState.player && !source.alive)) return;
 
                 const skillKeys = [
                     source.skill,

--- a/tests/playerAuraDisplay.test.js
+++ b/tests/playerAuraDisplay.test.js
@@ -1,0 +1,47 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, assignSkill, updateTurnEffects, updateUnitEffectIcons } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  // setup minimal dungeon and player position
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+
+  // give player an aura skill
+  assignSkill(1, 'MightAura');
+  gameState.player.skillLevels['MightAura'] = 1;
+
+  // update UI elements
+  const cellDiv = win.document.createElement('div');
+  updateUnitEffectIcons(gameState.player, cellDiv);
+  updateTurnEffects();
+
+  const buffContainer = cellDiv.querySelector('.buff-container');
+  const icon = SKILL_DEFS['MightAura'].icon;
+  if (!buffContainer || !buffContainer.textContent.includes(icon)) {
+    console.error('player aura icon missing on tile');
+    process.exit(1);
+  }
+
+  const panel = win.document.getElementById('turn-effects');
+  if (!panel.innerHTML.includes(icon)) {
+    console.error('player aura icon missing in turn-effects');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- allow player auras even when dead when fetching active icons
- test that player aura icons show on player tile and in turn-effects panel

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684938d2aeb883278e2d34f4a2f1b75a