### PR TITLE
Improve buff/status container layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,6 +179,7 @@
   left: 0;
   width: 100%;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   pointer-events: none; /* 아이콘이 마우스 클릭을 방해하지 않도록 설정 */

--- a/tests/effectIconsLayout.test.js
+++ b/tests/effectIconsLayout.test.js
@@ -1,0 +1,59 @@
+const { loadGame } = require('./helpers');
+const fs = require('fs');
+const path = require('path');
+
+async function run() {
+  const win = await loadGame();
+  // inject CSS so computed styles are available
+  const styleEl = win.document.createElement('style');
+  styleEl.textContent = fs.readFileSync(path.join(__dirname, '..', 'style.css'), 'utf8');
+  win.document.head.appendChild(styleEl);
+
+  // override getActiveAuraIcons to return multiple icons
+  win.getActiveAuraIcons = () => ['🔥', '🛡️', '❄️', '⚡', '💨'];
+
+  const unit = {
+    poison: true, poisonTurns: 1,
+    burn: true, burnTurns: 1,
+    freeze: true, freezeTurns: 1,
+    bleed: true, bleedTurns: 1
+  };
+
+  const div = win.document.createElement('div');
+  div.style.width = '32px';
+  div.style.height = '32px';
+  div.style.position = 'relative';
+  win.document.body.appendChild(div);
+
+  win.updateUnitEffectIcons(unit, div);
+
+  const buff = div.querySelector('.buff-container');
+  const status = div.querySelector('.status-container');
+
+  if (!buff || !status) {
+    console.error('containers not created');
+    process.exit(1);
+  }
+
+  if (buff.children.length !== 5 || status.children.length !== 4) {
+    console.error('icons not added');
+    process.exit(1);
+  }
+
+  const buffStyle = win.getComputedStyle(buff);
+  const statusStyle = win.getComputedStyle(status);
+
+  if (buffStyle.display !== 'flex' || statusStyle.display !== 'flex') {
+    console.error('display style incorrect');
+    process.exit(1);
+  }
+
+  if (buffStyle.flexWrap !== 'wrap' || statusStyle.flexWrap !== 'wrap') {
+    console.error('flex-wrap missing');
+    process.exit(1);
+  }
+
+  console.log('icon layout ok');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- ensure buff/status containers wrap their contents to avoid overlapping icons
- add a regression test confirming effect icon layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684938d382a88327bb4d67fc2ea79510