### PR TITLE
Add tile arrays and slot

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3124,7 +3124,7 @@ function killMonster(monster) {
                 affinity: 30,
                 fullness: 75,
                 hasActed: false,
-                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null },
+                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null },
                 range: monster.range,
                 special: monster.special,
                 trait: monster.trait || null,
@@ -4106,7 +4106,8 @@ function killMonster(monster) {
                     weapon: null,
                     armor: null,
                     accessory1: null,
-                    accessory2: null
+                    accessory2: null,
+                    tile: null
                 }
             };
         }

--- a/src/state.js
+++ b/src/state.js
@@ -55,6 +55,7 @@
       expNeeded: 20,
       gold: 1000,
       inventory: [],
+      tileInventory: [],
       skillPoints: 0,
       statPoints: 0,
       skillLevels: {},
@@ -64,7 +65,8 @@
         weapon: null,
         armor: null,
         accessory1: null,
-        accessory2: null
+        accessory2: null,
+        tile: null
       },
       teleportSavedX: null,
       teleportSavedY: null,
@@ -78,6 +80,7 @@
     corpses: [],
     treasures: [],
     items: [],
+    mapTiles: [],
     projectiles: [],
     exitLocation: { x: 0, y: 0 },
     altarLocation: { x: 0, y: 0 },

--- a/tests/tileState.test.js
+++ b/tests/tileState.test.js
@@ -1,0 +1,30 @@
+const { loadGame } = require('./helpers');
+const assert = require('assert');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, hireMercenary, createMonster, convertMonsterToMercenary } = win;
+
+  assert.strictEqual(gameState.player.equipped.tile, null, 'player tile slot not initialized');
+  assert.ok(Array.isArray(gameState.player.tileInventory), 'tileInventory not array');
+  assert.ok(Array.isArray(gameState.mapTiles), 'mapTiles not array');
+
+  gameState.player.gold = 500;
+  hireMercenary('WARRIOR');
+  const merc = gameState.activeMercenaries[0];
+  assert.ok(merc.equipped && 'tile' in merc.equipped && merc.equipped.tile === null, 'mercenary tile slot missing');
+
+  const monster = createMonster('GOBLIN', 0, 0, 1);
+  const merc2 = convertMonsterToMercenary(monster);
+  assert.ok('tile' in merc2.equipped && merc2.equipped.tile === null, 'converted mercenary tile slot missing');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- include tile slot in player and mercenary equipment
- add tileInventory and mapTiles arrays in game state
- test new tile-related properties

## Testing
- `npm install`
- `node runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6849587e5dc48327883106317e0d3831