### PR TITLE
Add tile tab UI panel and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,6 +784,7 @@
                     <div class="equipped-slot" id="equipped-armor">방어구: 없음</div>
                     <div class="equipped-slot" id="equipped-accessory1">악세서리1: 없음</div>
                     <div class="equipped-slot" id="equipped-accessory2">악세서리2: 없음</div>
+                    <div class="equipped-slot" id="equipped-tile">타일: 없음</div>
                 </div>
                 <h3>📦 보유 아이템</h3>
                 <div id="inventory-filters" style="margin-bottom: 10px; display: flex; flex-wrap: wrap; gap: 5px;">
@@ -903,6 +904,9 @@
     <div id="crafting-detail-panel" class="details-panel" style="display:none;">
         <div id="crafting-detail-list"></div>
         <button id="close-crafting-detail">닫기</button>
+    </div>
+    <div class="tile-tab-container">
+        <div id="tile-tab"></div>
     </div>
     <script src="dice.js"></script>
     <script type="module" src="src/state.js"></script>

--- a/style.css
+++ b/style.css
@@ -203,3 +203,37 @@
     /* 2. 가독성을 위해 뚜렷한 테두리 대신 부드러운 검은색 그림자를 살짝 추가합니다. */
     text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.9);
 }
+.tile-tab-container {
+  background: linear-gradient(135deg, #2a2a2a, #333);
+  padding: 15px;
+  border-radius: 8px;
+  border: 1px solid #555;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.tile-tab {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tile-tab-slot {
+  width: 32px;
+  height: 32px;
+  background-color: #222;
+  border: 1px solid #666;
+  border-radius: 4px;
+  position: relative;
+}
+
+.tile-tab-slot img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.equipped-tile-bg {
+  box-shadow: 0 0 5px 2px #4CAF50;
+}


### PR DESCRIPTION
## Summary
- extend inventory equipment list with equipped tile entry
- add tile tab container to detail panels in HTML
- style tile tab UI elements

## Testing
- `npm install`
- `npm test` *(fails: heal amount not scaled with level)*

------
https://chatgpt.com/codex/tasks/task_e_6849588199fc8327b19ec8b1136fc58f