### PR TITLE
Add tile slot support in getStat

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1850,6 +1850,9 @@ const MERCENARY_NAMES = [
                         value += it[stat];
                     }
                 });
+                if (character.equipped.tile && character.equipped.tile[stat] !== undefined) {
+                    value += character.equipped.tile[stat];
+                }
             }
             value += getAuraBonus(character, stat);
             return value;


### PR DESCRIPTION
## Summary
- include the `tile` equipment slot in stat calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684958842164832796fbeb6d5a6f0d2f