### PR TITLE
Add tile background rendering support

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3352,14 +3352,19 @@ function killMonster(monster) {
                     // 렌더링마다 이전 아이콘들을 모두 지워 잔상이 남지 않게 합니다.
                     const buffEl = div.querySelector('.buff-container');
                     const statusEl = div.querySelector('.status-container');
+                    const tileBgEl = div.querySelector('.equipped-tile-bg');
                     if (buffEl) buffEl.innerHTML = '';
                     if (statusEl) statusEl.innerHTML = '';
+                    if (tileBgEl) tileBgEl.style.backgroundImage = '';
                     const baseCellType = gameState.dungeon[y][x];
                     const finalClasses = ['cell', baseCellType];
                     div.textContent = '';
 
                     if (x === gameState.player.x && y === gameState.player.y) {
                         finalClasses.push('player');
+                        if (tileBgEl && gameState.player.equipped && gameState.player.equipped.tile && gameState.player.equipped.tile.image) {
+                            tileBgEl.style.backgroundImage = `url('${gameState.player.equipped.tile.image}')`;
+                        }
                         updateUnitEffectIcons(gameState.player, div);
                     } else {
                         const proj = gameState.projectiles.find(p => p.x === x && p.y === y);
@@ -3381,6 +3386,9 @@ function killMonster(monster) {
                                 else if (merc.isChampion) finalClasses.push('champion');
                                 else if (merc.isElite) finalClasses.push('elite');
                                 div.textContent = '';
+                                if (tileBgEl && merc.equipped && merc.equipped.tile && merc.equipped.tile.image) {
+                                    tileBgEl.style.backgroundImage = `url('${merc.equipped.tile.image}')`;
+                                }
                                 updateUnitEffectIcons(merc, div);
                             } else if (baseCellType === 'monster') {
                                 const m = gameState.monsters.find(mon => mon.x === x && mon.y === y);
@@ -3406,6 +3414,8 @@ function killMonster(monster) {
                                 div.textContent = '⛏️';
                             } else if (baseCellType === 'tree') {
                                 div.textContent = '🌳';
+                            } else if (baseCellType === 'tile') {
+                                // tile cells use background image only
                             } else if (baseCellType === 'bones') {
                                 div.textContent = '💀';
                             } else if (baseCellType === 'grave') {
@@ -3603,6 +3613,11 @@ function killMonster(monster) {
                         const statusContainer = document.createElement('div');
                         statusContainer.className = 'status-container';
                         cellDiv.appendChild(statusContainer);
+
+                        // 배경 타일 이미지 컨테이너
+                        const tileBg = document.createElement('div');
+                        tileBg.className = 'equipped-tile-bg';
+                        cellDiv.appendChild(tileBg);
 
                         dungeonEl.appendChild(cellDiv);
                         cellRow.push(cellDiv);

--- a/style.css
+++ b/style.css
@@ -34,6 +34,13 @@
   /* border: 1px solid #000; */
 }
 
+/* Decorative tile background */
+.cell.tile {
+  background-image: url("assets/images/floor-tile.png");
+  background-size: cover;
+  background-position: center;
+}
+
 .cell.empty.player {
   background-image: url("assets/images/player.png"), url("assets/images/floor-tile.png");
   background-size: contain, cover;
@@ -198,8 +205,18 @@
 
 .effect-icon {
     /* 1. color 속성을 되돌려 투명 상태를 해제하고, 이모티콘 고유색이 보이게 합니다. */
-    color: initial; 
+    color: initial;
     
     /* 2. 가독성을 위해 뚜렷한 테두리 대신 부드러운 검은색 그림자를 살짝 추가합니다. */
     text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.9);
+}
+
+/* Background for equipped tiles */
+.equipped-tile-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  pointer-events: none;
+  z-index: 0;
 }


### PR DESCRIPTION
## Summary
- generateDungeon: insert `.equipped-tile-bg` div for each cell
- renderDungeon: clear tile background each frame
- apply equipped tile images for player and mercenaries
- show decorative tile backgrounds
- style for tile cells and equipped tile backgrounds

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684958850da08327aaeeaa890049fd96