### PR TITLE
Fix mercenary equipment initialization in loadGame

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -6342,6 +6342,17 @@ function processTurn() {
                     if (m.skill) m.skillLevels[m.skill] = 1;
                     if (m.skill2) m.skillLevels[m.skill2] = 1;
                 }
+                if (!m.equipped) {
+                    m.equipped = {
+                        weapon: null,
+                        armor: null,
+                        accessory1: null,
+                        accessory2: null,
+                        tile: null
+                    };
+                } else if (!('tile' in m.equipped)) {
+                    m.equipped.tile = null;
+                }
             };
 
             gameState.activeMercenaries.forEach(convertMercenary);


### PR DESCRIPTION
## Summary
- ensure mercenaries loaded from old saves always have `equipped` with a `tile` slot

## Testing
- `npm test` *(fails: SyntaxError: Identifier 'TILE_TYPES' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68496521dc548327b158a359b59df4de