### PR TITLE
Add tile system with effects and UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -237,3 +237,7 @@
 .equipped-tile-bg {
   box-shadow: 0 0 5px 2px #4CAF50;
 }
+
+.low-health {
+  animation: monsterPulse 1s ease-in-out infinite alternate;
+}


### PR DESCRIPTION
## Summary
- define new tile types with stat effects
- show tile inventory with background images
- spawn tiles in dungeons and allow pickup
- render equipped tile backgrounds and low-health indicator
- include tile effects in stat calculation
- update load/start processes for tile tab
- style low-health pulsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849696b4a2c83278827b86e9f1e1e03