### PR TITLE
Add tile system state variables

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -98,10 +98,10 @@
     autoMoveActive: false,
     inventoryFilter: 'all',
     turn: 0,
-    incubators: [null, null],
+    incubators: [null, null, null],
     hatchedSuperiors: [],
     pendingMap: null,
-    currentMapModifiers: null,
+    currentMapModifiers: {},
     gameRunning: true
   };
   global.gameState = gameState;


### PR DESCRIPTION
## Summary
- support more incubator slots
- start map modifiers as an empty object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68496e63e6408327976bcbdbde75d70f