### PR TITLE
Fix duplicate ID and stats update

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,7 +847,7 @@
                 <div>⭐ 경험치: <span id="exp">0</span>/<span id="expNeeded">20</span></div>
                 <div>💰 골드: <span id="gold">0</span></div>
                 <div>🏰 층: <span id="floor">1</span></div>
-                <div id="equipped-tile">타일: 없음</div>
+                <div id="equipped-tile-side">타일: 없음</div>
             </div>
             
             <div class="mercenary-panel">

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2673,7 +2673,7 @@ function updateMaterialsDisplay() {
             document.getElementById('expNeeded').textContent = formatNumber(gameState.player.expNeeded);
             document.getElementById('gold').textContent = formatNumber(gameState.player.gold);
             document.getElementById('floor').textContent = formatNumber(gameState.floor);
-            const tileSlot = document.getElementById('equipped-tile');
+            const tileSlot = document.getElementById('equipped-tile-side');
             if (tileSlot) {
                 if (gameState.player.equipped.tile) {
                     tileSlot.textContent = `타일: ${formatItem(gameState.player.equipped.tile)}`;

--- a/tests/foodAffinity.test.js
+++ b/tests/foodAffinity.test.js
@@ -14,6 +14,7 @@ async function run() {
 
   const { hireMercenary, createItem, addToInventory, handleItemClick, gameState } = win;
 
+  gameState.player.gold = 500;
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
 

--- a/tests/healSelf.test.js
+++ b/tests/healSelf.test.js
@@ -22,6 +22,7 @@ async function run() {
   gameState.player.y = 2;
   gameState.dungeon[2][2] = 'empty';
 
+  gameState.player.gold = 500;
   hireMercenary('HEALER');
   const healer = gameState.activeMercenaries[0];
   healer.skill = 'Heal';

--- a/tests/itemTargetPrompt.test.js
+++ b/tests/itemTargetPrompt.test.js
@@ -12,6 +12,7 @@ async function run() {
 
   const { hireMercenary, createItem, addToInventory, handleItemClick, gameState } = win;
 
+  gameState.player.gold = 500;
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
 

--- a/tests/magicScaling.test.js
+++ b/tests/magicScaling.test.js
@@ -18,6 +18,8 @@ async function run() {
     gameState,
     getStat
   } = win;
+
+  gameState.player.gold = 500;
   const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
 
   const size = 5;

--- a/tests/mercenarySkill.test.js
+++ b/tests/mercenarySkill.test.js
@@ -20,6 +20,8 @@ async function run() {
     gameState
   } = win;
 
+  gameState.player.gold = 500;
+
   const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
 
   // create a simple empty dungeon

--- a/tests/rawMeat.test.js
+++ b/tests/rawMeat.test.js
@@ -13,6 +13,7 @@ async function run() {
 
   const { hireMercenary, createItem, addToInventory, handleItemClick, gameState } = win;
 
+  gameState.player.gold = 500;
   hireMercenary('WARRIOR');
   const merc = gameState.activeMercenaries[0];
 


### PR DESCRIPTION
## Summary
- rename the stats tile element to `equipped-tile-side`
- update `updateStats()` to use the new ID
- keep inventory display referencing `equipped-tile`
- adjust tests to supply gold before hiring mercenaries

## Testing
- `npm install`
- `npm test` *(fails: `mana.test.js` - mana not used or regenerated correctly)*

------
https://chatgpt.com/codex/tasks/task_e_684978e6a80483278501fe9a8a119543