### PR TITLE
Set starting gold to 1000

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7056,6 +7056,8 @@ function processTurn() {
         function startGame() {
             // SoundEngine.initialize(); // 오디오 초기화는 사용자 입력 후 수행
             gameState.player.job = null;
+            // Ensure player starts with initial gold
+            gameState.player.gold = 1000;
             const allSkills = Object.keys(SKILL_DEFS);
             gameState.player.skillPoints = 0;
             gameState.player.statPoints = 0;

--- a/src/state.js
+++ b/src/state.js
@@ -24,7 +24,7 @@
             intelligence: 0,
             skillPoints: 0,
             statPoints: 0,
-            gold: 0,
+            gold: 1000,
             fullness: 0,
             skills: [],
             skillLevels: {},


### PR DESCRIPTION
## Summary
- give the player 1000 gold at the start of a new game
- ensure `startGame` keeps this value

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684983defa148327b1e24e642e8ce20b