### PR TITLE
Disable text selection in dungeon

### DIFF
--- a/style.css
+++ b/style.css
@@ -335,3 +335,10 @@
   flex-wrap: wrap;
   gap: 5px;
 }
+.dungeon-container, .dungeon, .cell {
+  user-select: none;
+}
+
+.cell:focus {
+  outline: none;
+}


### PR DESCRIPTION
## Summary
- prevent text selection and focus outlines for dungeon elements

## Testing
- `npm test` *(fails: mana not used or regenerated correctly)*

------
https://chatgpt.com/codex/tasks/task_e_684983e8bbb08327b0164239b751b410