### PR TITLE
Add corpse decay mechanic

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -394,6 +394,7 @@ const MERCENARY_NAMES = [
 
         const MAX_FULLNESS = 100;
         const FULLNESS_LOSS_PER_TURN = 0.01;
+        const CORPSE_TURNS = 30; // how long a corpse remains on the map
         const CORRIDOR_WIDTH = 7; // width of dungeon corridors
 
         function carveWideCorridor(map, x1, y1, x2, y2) {
@@ -3126,6 +3127,7 @@ function killMonster(monster) {
             const idx = gameState.monsters.findIndex(m => m === monster);
             if (idx !== -1) gameState.monsters.splice(idx, 1);
             monster.health = 0;
+            monster.turnsLeft = CORPSE_TURNS;
             gameState.corpses.push(monster);
             gameState.dungeon[monster.y][monster.x] = 'corpse';
         }
@@ -5450,6 +5452,16 @@ function processTurn() {
     if (!gameState.gameRunning) return;
     gameState.turn++;
 
+    for (let i = gameState.corpses.length - 1; i >= 0; i--) {
+        const corpse = gameState.corpses[i];
+        corpse.turnsLeft--;
+        if (corpse.turnsLeft <= 0) {
+            gameState.corpses.splice(i, 1);
+            const hasItem = gameState.items.some(it => it.x === corpse.x && it.y === corpse.y);
+            gameState.dungeon[corpse.y][corpse.x] = hasItem ? 'item' : 'empty';
+        }
+    }
+
             const starvedMercs = [];
             const starvedMonsters = [];
             [...gameState.activeMercenaries, ...gameState.standbyMercenaries].forEach(m => {
@@ -5998,6 +6010,7 @@ function processTurn() {
                             gameState.monsters.splice(monsterIndex, 1);
                         }
                         nearestMonster.health = 0;
+                        nearestMonster.turnsLeft = CORPSE_TURNS;
                         gameState.corpses.push(nearestMonster);
                         gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
                     }
@@ -6076,6 +6089,7 @@ function processTurn() {
                             gameState.monsters.splice(monsterIndex, 1);
                         }
                         nearestMonster.health = 0;
+                        nearestMonster.turnsLeft = CORPSE_TURNS;
                         gameState.corpses.push(nearestMonster);
                         gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
                     }
@@ -6163,6 +6177,7 @@ function processTurn() {
                             gameState.monsters.splice(monsterIndex, 1);
                         }
                         nearestMonster.health = 0;
+                        nearestMonster.turnsLeft = CORPSE_TURNS;
                         gameState.corpses.push(nearestMonster);
                         gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
                     }
@@ -6240,6 +6255,7 @@ function processTurn() {
                             gameState.monsters.splice(monsterIndex, 1);
                         }
                         nearestMonster.health = 0;
+                        nearestMonster.turnsLeft = CORPSE_TURNS;
                         gameState.corpses.push(nearestMonster);
                         gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
                     }
@@ -7217,5 +7233,5 @@ upgradeMercenarySkill, upgradeMonsterSkill, useItem, useItemOnTarget, useSkill, 
     updateCraftingDetailDisplay, showCraftingDetailPanel, hideCraftingDetailPanel,
     showCorpsePanel, hideCorpsePanel, ignoreCorpse, getMonsterRank
 };
-Object.assign(window, exportsObj, {SKILL_DEFS, MERCENARY_SKILLS, MONSTER_SKILLS, MONSTER_SKILL_SETS, MONSTER_TRAITS, MONSTER_TRAIT_SETS, PREFIXES, SUFFIXES, MAP_PREFIXES, MAP_SUFFIXES, MAP_TILE_TYPES});
+Object.assign(window, exportsObj, {SKILL_DEFS, MERCENARY_SKILLS, MONSTER_SKILLS, MONSTER_SKILL_SETS, MONSTER_TRAITS, MONSTER_TRAIT_SETS, PREFIXES, SUFFIXES, MAP_PREFIXES, MAP_SUFFIXES, MAP_TILE_TYPES, CORPSE_TURNS});
 

--- a/tests/corpseDecay.test.js
+++ b/tests/corpseDecay.test.js
@@ -1,0 +1,49 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createMonster, killMonster, processTurn, gameState } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 0;
+  gameState.player.y = 0;
+  gameState.monsters = [];
+  gameState.corpses = [];
+  gameState.items = [];
+
+  const monster = createMonster('GOBLIN', 1, 1, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[1][1] = 'monster';
+  killMonster(monster);
+
+  if (!gameState.corpses.includes(monster) || typeof monster.turnsLeft !== 'number') {
+    console.error('corpse not recorded with turns');
+    process.exit(1);
+  }
+
+  const turns = monster.turnsLeft;
+  for (let i = 0; i < turns; i++) {
+    processTurn();
+  }
+
+  if (gameState.corpses.includes(monster)) {
+    console.error('corpse not removed after duration');
+    process.exit(1);
+  }
+  if (gameState.dungeon[1][1] !== 'empty') {
+    console.error('dungeon tile not cleared after corpse decay');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add `CORPSE_TURNS` constant and export it
- mark corpses with `turnsLeft` when monsters die
- decay corpses during `processTurn`
- remove expired corpses from dungeon
- test that corpses vanish after their timer runs out

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684983e299f08327ad531f255b17ffe1