### PR TITLE
Add npm install pretest step

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,16 @@ npm install
 
 ## Testing
 
-Before running the tests you must install the project dependencies manually:
+The test suite relies on development dependencies such as **jsdom**. Ensure they
+are installed by running:
 
 ```bash
 npm install
 ```
 
-After installation execute `npm test` to run the test suite. The test runner
+You can simply run `npm test` as well – the `pretest` script in
+`package.json` automatically installs all dependencies before executing the test
+runner. After installation the test runner
 automatically locates all files ending with `*.test.js` in the `tests` folder
 and executes them sequentially.
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "This project is a lightweight browser-based dungeon crawler. It lets players explore levels, battle enemies and gather loot directly in the browser.",
   "scripts": {
+    "pretest": "npm install",
     "test": "node runTests.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- document test setup so that dev dependencies are installed
- automatically run `npm install` before tests with a new `pretest` script

## Testing
- `npm install`
- `npm test` *(fails: mana.test.js failed with `mana not used or regenerated correctly`)*

------
https://chatgpt.com/codex/tasks/task_e_684989b9e37483278292435109e1a915