### PR TITLE
Fix mercenary corpse cleanup

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4931,11 +4931,10 @@ function killMonster(monster) {
 
             mercenary.alive = false;
             mercenary.health = 0;
-            mercenary.turnsLeft = CORPSE_TURNS;
-            gameState.corpses.push(mercenary);
 
             if (gameState.dungeon[mercenary.y] && gameState.dungeon[mercenary.y][mercenary.x]) {
-                gameState.dungeon[mercenary.y][mercenary.x] = 'corpse';
+                const hasItem = gameState.items.some(i => i.x === mercenary.x && i.y === mercenary.y);
+                gameState.dungeon[mercenary.y][mercenary.x] = hasItem ? 'item' : 'empty';
             }
 
             mercenary.affinity = Math.max(0, (mercenary.affinity || 0) - 5);


### PR DESCRIPTION
## Summary
- remove corpse generation when a mercenary dies
- clear the dungeon cell immediately after mercenary death

## Testing
- `npm test` *(fails: `mana.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684998ba62f48327a80548e23af4f9f0