### PR TITLE
Extend corpse decay timer

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -394,7 +394,7 @@ const MERCENARY_NAMES = [
 
         const MAX_FULLNESS = 100;
         const FULLNESS_LOSS_PER_TURN = 0.01;
-        const CORPSE_TURNS = 30; // how long a corpse remains on the map
+        const CORPSE_TURNS = 60; // how long a corpse remains on the map
         const CORRIDOR_WIDTH = 7; // width of dungeon corridors
 
         function carveWideCorridor(map, x1, y1, x2, y2) {


### PR DESCRIPTION
## Summary
- keep monster corpses around longer

## Testing
- `npm test --silent` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684998bbc37c832793df131a016cd784