### PR TITLE
Spawn starter tiles near player

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1487,7 +1487,7 @@ const MERCENARY_NAMES = [
             let y = y1;
             while (x !== x2 || y !== y2) {
                 if (x !== x1 || y !== y1) {
-                    if (gameState.dungeon[y][x] === 'wall') return false;
+                    if (!gameState.dungeon[y] || gameState.dungeon[y][x] === undefined || gameState.dungeon[y][x] === 'wall') return false;
                 }
                 if (x !== x2) x += dx;
                 if (y !== y2) y += dy;
@@ -1498,6 +1498,8 @@ const MERCENARY_NAMES = [
         // BFS 경로 탐색
         function findPath(startX, startY, targetX, targetY) {
             const size = gameState.dungeonSize;
+            if (startX < 0 || startY < 0 || startX >= size || startY >= size) return null;
+            if (targetX < 0 || targetY < 0 || targetX >= size || targetY >= size) return null;
             const queue = [[startX, startY]];
             let head = 0;
             const visited = Array.from({ length: size }, () => Array(size).fill(false));
@@ -7118,6 +7120,17 @@ function processTurn() {
             }
         }
 
+        function spawnStartingTiles() {
+            const tileKeys = [TILE_TYPES.FLOWER, TILE_TYPES.VOLCANO, TILE_TYPES.METAL];
+            tileKeys.forEach(key => {
+                const pos = findAdjacentEmpty(gameState.player.x, gameState.player.y);
+                if (pos.x === gameState.player.x && pos.y === gameState.player.y) return;
+                const tileData = { ...TILE_DEFS[key], x: pos.x, y: pos.y };
+                gameState.mapTiles.push(tileData);
+                gameState.dungeon[pos.y][pos.x] = 'tile';
+            });
+        }
+
         function startGame() {
             // SoundEngine.initialize(); // 오디오 초기화는 사용자 입력 후 수행
             gameState.player.job = null;
@@ -7147,6 +7160,7 @@ function processTurn() {
                 gameState.player.inventory.push(createItem('smallExpScroll', 0, 0));
             }
             spawnStartingRecipes();
+            spawnStartingTiles();
             updateInventoryDisplay();
             updateSkillDisplay();
             updateIncubatorDisplay();
@@ -7273,7 +7287,7 @@ removeEggFromIncubator, renderDungeon, reviveMercenary, reviveMonsterCorpse,
  rollDice, saveGame, sellItem, confirmAndSell, enhanceItem, disassembleItem, setMercenaryLevel, setMonsterLevel, setChampionLevel,
 showChampionDetails, showItemDetailPanel, showItemTargetPanel, showMercenaryDetails,
 showMonsterDetails, showShop, showSkillDamage, showAuraDetails, skill1Action, skill2Action,
-spawnMercenaryNearPlayer, spawnStartingRecipes, startGame, swapActiveAndStandby, tryApplyStatus,
+spawnMercenaryNearPlayer, spawnStartingRecipes, spawnStartingTiles, startGame, swapActiveAndStandby, tryApplyStatus,
 unequipAccessory, unequipWeapon, unequipArmor, unequipItemFromMercenary, updateActionButtons, updateCamera,
 updateFogOfWar, updateIncubatorDisplay,
  updateInventoryDisplay, updateMaterialsDisplay, updateMercenaryDisplay,

--- a/src/state.js
+++ b/src/state.js
@@ -22,6 +22,7 @@
             endurance: 10,
             focus: 5,
             intelligence: 0,
+            manaRegen: 0.5,
             skillPoints: 0,
             statPoints: 0,
             gold: 1000,

--- a/tests/startingTiles.test.js
+++ b/tests/startingTiles.test.js
@@ -1,0 +1,46 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { spawnStartingTiles, gameState } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.mapTiles = [];
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+
+  spawnStartingTiles();
+
+  const expected = ['flower', 'volcano', 'metal'];
+  for (const type of expected) {
+    if (!gameState.mapTiles.some(t => t.key === type)) {
+      console.error('missing tile ' + type);
+      process.exit(1);
+    }
+  }
+
+  if (gameState.mapTiles.length !== expected.length) {
+    console.error('tile count mismatch');
+    process.exit(1);
+  }
+
+  for (const tile of gameState.mapTiles) {
+    if (gameState.dungeon[tile.y][tile.x] !== 'tile') {
+      console.error('tile not placed on map');
+      process.exit(1);
+    }
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- drop flower, lava, and metal tiles around the player at the start of a new game
- export helper to spawn these starter tiles
- ensure player regenerates mana by giving a base manaRegen stat
- guard line-of-sight and pathfinding utilities against out-of-bounds access
- test that starter tiles spawn correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68499874b1f483279ed2e7cd3f2e3b20