### PR TITLE
Remove visible caret on game screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
             padding: 10px;
             min-height: 100vh;
             box-sizing: border-box;
+            /* Hide the text caret that appears when the body gains focus */
+            caret-color: transparent;
         }
         h1 {
             color: #ff6600;


### PR DESCRIPTION
## Summary
- hide the text caret when the body gains focus by setting `caret-color` to transparent

## Testing
- `npm test` *(fails: mana.test.js not used or regenerated correctly)*

------
https://chatgpt.com/codex/tasks/task_e_68499bc33ff88327b1f699e99a79dcfd