### PR TITLE
Fix duplicated fields in game state

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -64,18 +64,15 @@
         activeRecipes: ['healthPotion', 'sandwich', 'salad'],
         craftingQueue: [],
         floor: 1,
-        dungeonSize: 80,
         viewportSize: 25,
         camera: { x: 0, y: 0 },
         autoMovePath: null,
         autoMoveActive: false,
         inventoryFilter: 'all',
-        turn: 0,
         incubators: [null, null, null],
         hatchedSuperiors: [],
         pendingMap: null,
-        currentMapModifiers: {},
-        gameRunning: true
+        currentMapModifiers: {}
     };
     global.gameState = gameState;
     global.MONSTER_VISION = MONSTER_VISION;


### PR DESCRIPTION
## Summary
- remove duplicate `turn`, `dungeonSize` and `gameRunning` fields from `gameState`

## Testing
- `node runTests.js` *(fails: `monsterExp.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a28de0308327ba21edbb136b380f