### PR TITLE
Add monster aura icon test

### DIFF
--- a/tests/monsterAuraDisplay.test.js
+++ b/tests/monsterAuraDisplay.test.js
@@ -1,0 +1,43 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createEliteMonster, gameState, updateUnitEffectIcons } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+
+  const origRandom = win.Math.random;
+  win.Math.random = () => 0; // select first aura skill
+  const monster = createEliteMonster('GOBLIN', 2, 1, 1);
+  win.Math.random = origRandom;
+
+  gameState.monsters = [monster];
+  gameState.dungeon[1][2] = 'monster';
+  monster.alive = true;
+
+  const cellDiv = win.document.createElement('div');
+  updateUnitEffectIcons(monster, cellDiv);
+
+  const buffContainer = cellDiv.querySelector('.buff-container');
+  const icon = SKILL_DEFS[monster.auraSkill].icon;
+  if (!buffContainer || !buffContainer.textContent.includes(icon)) {
+    console.error('monster aura icon missing');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add a new test to ensure aura icons for elite monsters are rendered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a28ed3d8832787bcde2af9c3809c