### PR TITLE
Add multiple stairs per floor

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3808,18 +3808,24 @@ function killMonster(monster) {
                 });
             }
 
-            let exitX = 1, exitY = 1;
-            if (visitedCells.length > 1) {
-                let exitCell;
-                do {
-                    exitCell = visitedCells[Math.floor(Math.random() * visitedCells.length)];
-                } while (exitCell.x === 1 && exitCell.y === 1);
-                exitX = exitCell.x;
-                exitY = exitCell.y;
+            gameState.exitLocations = [];
+            let exitCount = Math.floor(Math.random() * 4) + 1; // 1~4개 출구 생성
+            for (let i = 0; i < exitCount; i++) {
+                let exitX = 1, exitY = 1;
+                if (visitedCells.length > 1) {
+                    let exitCell;
+                    do {
+                        exitCell = visitedCells[Math.floor(Math.random() * visitedCells.length)];
+                    } while ((exitCell.x === 1 && exitCell.y === 1) || gameState.dungeon[exitCell.y][exitCell.x] === 'exit');
+                    exitX = exitCell.x;
+                    exitY = exitCell.y;
+                }
+                gameState.exitLocations.push({ x: exitX, y: exitY });
+                gameState.dungeon[exitY][exitX] = 'exit';
             }
-
-            gameState.exitLocation = { x: exitX, y: exitY };
-            gameState.dungeon[exitY][exitX] = 'exit';
+            if (gameState.exitLocations.length) {
+                gameState.exitLocation = gameState.exitLocations[0];
+            }
 
             const monsterTypes = getMonsterPoolForFloor(dungeonLevel);
             // 몬스터는 던전 크기와 층수에 비례해 등장 수를 결정

--- a/src/state.js
+++ b/src/state.js
@@ -56,6 +56,7 @@
         mapTiles: [], // <<< 수정됨: 맵에 생성된 타일 위치 정보 추가
         projectiles: [],
         exitLocation: { x: 0, y: 0 },
+        exitLocations: [],
         altarLocation: { x: 0, y: 0 },
         shopLocation: { x: 0, y: 0 },
         shopItems: [],


### PR DESCRIPTION
## Summary
- track all stairs in `exitLocations`
- place 1-4 exit stairs randomly each floor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ad3757e08327a588607c3a7603e1