### PR TITLE
Add attacker tracking for projectiles

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1967,19 +1967,20 @@ const MERCENARY_NAMES = [
 
                 const monster = gameState.monsters.find(m => m.x === nx && m.y === ny);
                 if (monster) {
+                    const attacker = proj.attacker || gameState.player;
                     let attackValue;
                     let magic = !!proj.magic;
                     if (proj.damageDice !== undefined) {
                         attackValue = rollDice(proj.damageDice) * (proj.level || 1);
                         if (magic) {
-                            attackValue += getStat(gameState.player, 'magicPower');
+                            attackValue += getStat(attacker, 'magicPower');
                         }
                     } else if (magic) {
-                        attackValue = getStat(gameState.player, 'magicPower');
+                        attackValue = getStat(attacker, 'magicPower');
                     } else {
-                        attackValue = getStat(gameState.player, 'attack');
+                        attackValue = getStat(attacker, 'attack');
                     }
-                    const result = performAttack(gameState.player, monster, { attackValue, magic, element: proj.element, status: gameState.player.equipped.weapon && gameState.player.equipped.weapon.status, damageDice: proj.damageDice });
+                    const result = performAttack(attacker, monster, { attackValue, magic, element: proj.element, status: attacker.equipped && attacker.equipped.weapon && attacker.equipped.weapon.status, damageDice: proj.damageDice });
                     const icon = proj.icon || '➡️';
                     const name = proj.skill ? SKILL_DEFS[proj.skill].name : '원거리 공격';
                     const detail = buildAttackDetail('원거리 공격', name, result);
@@ -4457,11 +4458,11 @@ function killMonster(monster) {
             return champion;
         }
 
-        function createHomingProjectile(x, y, target) {
+        function createHomingProjectile(x, y, target, attacker = gameState.player) {
             const dx = Math.sign(target.x - x);
             const dy = Math.sign(target.y - y);
             const dist = getDistance(x, y, target.x, target.y);
-            const proj = { x, y, dx, dy, rangeLeft: dist, icon: '🔺', homing: true, target };
+            const proj = { x, y, dx, dy, rangeLeft: dist, icon: '🔺', homing: true, target, attacker };
             gameState.projectiles.push(proj);
             return proj;
         }
@@ -6277,6 +6278,12 @@ function processTurn() {
             
             if (nearestMonster) {
                 if (nearestDistance <= attackRange) {
+                    if (mercenary.role === 'ranged') {
+                        createHomingProjectile(mercenary.x, mercenary.y, nearestMonster, mercenary);
+                        addMessage('🏹 원거리 공격', 'mercenary');
+                        mercenary.hasActed = true;
+                        return;
+                    }
                     // 공격 (장비 보너스 적용)
                     const totalAttack = getStat(mercenary, 'attack');
 
@@ -6552,7 +6559,8 @@ function processTurn() {
                 icon: '➡️',
                 element: null,
                 homing: true,
-                target
+                target,
+                attacker: gameState.player
             });
             processTurn();
         }
@@ -6821,7 +6829,8 @@ function processTurn() {
                 magic: skill.magic,
                 skill: skillKey,
                 element: skill.element,
-                level
+                level,
+                attacker: gameState.player
             };
             if (skillKey === 'Fireball' || skillKey === 'Iceball') {
                 proj.homing = true;

--- a/tests/magicProjectile.test.js
+++ b/tests/magicProjectile.test.js
@@ -19,7 +19,7 @@ async function run() {
   gameState.monsters.push(monster);
   gameState.dungeon[monster.y][monster.x] = 'monster';
 
-  const proj = { x: gameState.player.x, y: gameState.player.y, dx: 1, dy: 0, rangeLeft: 1, damageDice: '1d10', magic: true };
+  const proj = { x: gameState.player.x, y: gameState.player.y, dx: 1, dy: 0, rangeLeft: 1, damageDice: '1d10', magic: true, attacker: gameState.player };
   gameState.projectiles.push(proj);
 
   win.rollDice = () => 10;


### PR DESCRIPTION
## Summary
- track attacker on projectiles
- calculate projectile damage using projectile.attacker
- set attacker for player skills and ranged attacks
- allow ranged mercenaries to fire projectiles
- update tests for new projectile fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ae720a7883279ed13a97938b6d09