### PR TITLE
Update champion monster rendering

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3484,10 +3484,14 @@ function killMonster(monster) {
                             } else if (baseCellType === 'monster') {
                                 const m = gameState.monsters.find(mon => mon.x === x && mon.y === y);
                                 if (m) {
-                                    const monsterClass = m.type.replace('_', '-').toLowerCase();
-                                    finalClasses.push('monster', monsterClass);
-                                    if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer' && monsterClass !== 'goblin') {
-                                         div.textContent = m.icon;
+                                    if (m.isChampion) {
+                                        finalClasses.push('mercenary', m.type.toLowerCase());
+                                    } else {
+                                        const monsterClass = m.type.replace('_', '-').toLowerCase();
+                                        finalClasses.push('monster', monsterClass);
+                                        if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer' && monsterClass !== 'goblin') {
+                                             div.textContent = m.icon;
+                                        }
                                     }
                                     const maxHealth = getStat(m, 'maxHealth');
                                     if (maxHealth > 0 && m.health / maxHealth < 0.25) {


### PR DESCRIPTION
## Summary
- treat champion monsters as mercenaries in the renderDungeon function
- keep HP and status glow logic for monsters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849b5ee1bb483278ca80593d51acdc6