### PR TITLE
Add kill quotes for mercenary kills

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -310,6 +310,21 @@ function initializeAudio() {
     console.log("All audio systems initialized by user action.");
 }
 
+/**
+ * Play a random kill quote for the given mercenary.
+ * Chooses one of the two voice lines based on mercenary type.
+ */
+function playRandomKillQuote(mercenary) {
+    if (!mercenary || !mercenary.type) return;
+    const type = mercenary.type.toLowerCase();
+    const files = [
+        `assets/audio/${type}_kill_1.mp3`,
+        `assets/audio/${type}_kill_2.mp3`
+    ];
+    const file = files[Math.floor(Math.random() * files.length)];
+    playSoundFile(file);
+}
+
 // ========================== 추가 끝 ==========================
 
 const ITEM_TYPES = {
@@ -6088,6 +6103,7 @@ function processTurn() {
                     }
 
                     if (nearestMonster.health <= 0) {
+                        playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary");
 
                         const mercExp = Math.floor(nearestMonster.exp * 0.6);
@@ -6167,6 +6183,7 @@ function processTurn() {
                     }
 
                     if (nearestMonster.health <= 0) {
+                        playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary");
 
                         const mercExp = Math.floor(nearestMonster.exp * 0.6);
@@ -6255,6 +6272,7 @@ function processTurn() {
                     }
 
                     if (nearestMonster.health <= 0) {
+                        playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary");
 
                         const mercExp = Math.floor(nearestMonster.exp * 0.6);
@@ -6339,6 +6357,7 @@ function processTurn() {
                     }
                     
                     if (nearestMonster.health <= 0) {
+                        playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary");
                         
                         const mercExp = Math.floor(nearestMonster.exp * 0.6);


### PR DESCRIPTION
## Summary
- add `playRandomKillQuote` helper to play mercenary kill voice lines
- trigger kill quotes when mercenaries defeat monsters

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849c01b555483278c7a7fb109b11233