### PR TITLE
Decorative map tiles

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4044,7 +4044,8 @@ function killMonster(monster) {
             }
 
             const tileKeys = Object.values(TILE_TYPES);
-            const tileCount = 1 + Math.floor(Math.random() * 2);
+            // Spawn decorative tiles more liberally across the map
+            const tileCount = Math.floor(size * size * 0.015);
             for (let i = 0; i < tileCount; i++) {
                 let tx, ty;
                 do {
@@ -5401,14 +5402,7 @@ function killMonster(monster) {
             }
 
             if (cellType === 'tile') {
-                const tileIndex = gameState.mapTiles.findIndex(t => t.x === newX && t.y === newY);
-                if (tileIndex !== -1) {
-                    const [tileData] = gameState.mapTiles.splice(tileIndex, 1);
-                    gameState.player.tileInventory.push(tileData);
-                    addMessage(`💠 ${tileData.name}을(를) 획득했습니다!`, 'treasure');
-                    updateTileTabDisplay();
-                    gameState.dungeon[newY][newX] = 'empty';
-                }
+                // Decorative map tiles no longer grant items
             }
 
             if (cellType === 'plant') {


### PR DESCRIPTION
## Summary
- treat flower, volcano and metal as decorative tiles
- place more map tiles during dungeon generation
- ignore tile pickup when the player steps on them

## Testing
- `npm test` *(fails: healerPurify.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6849ceaafbdc832799d3db5c1f161e9c