### PR TITLE
Reduce idle dialogue frequency

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5970,8 +5970,8 @@ function processTurn() {
             updateIncubatorDisplay();
 
             // [추가된 유휴 대사 시스템]
-            // 이번 턴에 전투가 없었고, 3% 확률을 통과했을 때 대사를 출력합니다.
-            if (!combatOccurredInTurn && Math.random() < 0.03) {
+            // 이번 턴에 전투가 없었고, 0.3% 확률을 통과했을 때 대사를 출력합니다.
+            if (!combatOccurredInTurn && Math.random() < 0.003) {
                 const livingMercenaries = gameState.activeMercenaries.filter(m => m.alive);
 
                 if (livingMercenaries.length > 0) {


### PR DESCRIPTION
## Summary
- mercenary idle dialogue was playing too often
- shrink the probability of a non-combat quote

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ddf6bca48327a9d407f2797978d4