### PR TITLE
Fix champion monster display

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3638,6 +3638,12 @@ function killMonster(monster) {
                                 const m = gameState.monsters.find(mon => mon.x === x && mon.y === y);
                                 if (m) {
                                     if (m.isChampion) {
+                                        // 1. 'monster' 클래스를 'empty'로 교체
+                                        const monsterClassIndex = finalClasses.indexOf('monster');
+                                        if (monsterClassIndex > -1) {
+                                            finalClasses[monsterClassIndex] = 'empty';
+                                        }
+                                        // 2. 용병과 직업 클래스 추가
                                         finalClasses.push('mercenary', m.type.toLowerCase());
                                     } else {
                                         const monsterClass = m.type.replace('_', '-').toLowerCase();


### PR DESCRIPTION
## Summary
- treat champion monsters as allied units when rendering

## Testing
- `npm test` *(fails: heal did not heal ally or mana wrong)*

------
https://chatgpt.com/codex/tasks/task_e_6849de79f3048327b64155f4be5c0550