### PR TITLE
Fix monster tile persistence after projectile hits

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2119,6 +2119,10 @@ const MERCENARY_NAMES = [
                     }
                     if (monster.health <= 0) {
                         killMonster(monster);
+                    } else {
+                        // Ensure the tile retains the monster type so rendering
+                        // shows the monster after projectile disappears
+                        gameState.dungeon[monster.y][monster.x] = 'monster';
                     }
                     continue;
                 }


### PR DESCRIPTION
## Summary
- ensure projectile hits don't clear the monster tile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a3b1b66bc83278f6f15ca91d39d42