### PR TITLE
Fix champion tile overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -148,6 +148,9 @@
 }
 
 .cell.champion {
+  /* BUG FIX: 챔피언 셀의 배경색을 명시적으로 투명하게 설정하여 
+     하위 바닥 타일 이미지가 보이도록 수정합니다. */
+  background-color: transparent;
   box-shadow: 0 0 8px rgba(255, 235, 59, 0.7);
   animation: monsterPulse 1.5s ease-in-out infinite alternate;
 }


### PR DESCRIPTION
## Summary
- ensure champion cell background is transparent

## Testing
- `npm test` *(fails: Unable to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b9a07208327b877cbeedad698c7