### PR TITLE
Fix monster sprite rendering for new enemies

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3623,7 +3623,11 @@ function killMonster(monster) {
                                     } else {
                                         const monsterClass = m.type.replace('_', '-').toLowerCase();
                                         finalClasses.push('monster', monsterClass);
-                                        if (monsterClass !== 'slime' && monsterClass !== 'goblin-archer' && monsterClass !== 'goblin') {
+
+                                        // BUG FIX: 이미지 스프라이트가 있는 몬스터 목록에 4종을 추가하여
+                                        // 불필요한 텍스트 아이콘이 표시되지 않도록 수정합니다.
+                                        const monstersWithSprites = ['slime', 'goblin-archer', 'goblin', 'zombie', 'kobold', 'skeleton', 'goblin-wizard'];
+                                        if (!monstersWithSprites.includes(monsterClass)) {
                                              div.textContent = m.icon;
                                         }
                                     }

--- a/style.css
+++ b/style.css
@@ -141,6 +141,26 @@
   background-image: url("assets/images/goblin.png"), url("assets/images/floor-tile.png");
 }
 
+/* 좀비 이미지 적용 */
+.cell.monster.zombie {
+  background-image: url("assets/images/zombie.png"), url("assets/images/floor-tile.png");
+}
+
+/* 코볼트 이미지 적용 */
+.cell.monster.kobold {
+  background-image: url("assets/images/kobold.png"), url("assets/images/floor-tile.png");
+}
+
+/* 스켈레톤 이미지 적용 */
+.cell.monster.skeleton {
+  background-image: url("assets/images/skeleton.png"), url("assets/images/floor-tile.png");
+}
+
+/* 고블린 마법사 이미지 적용 */
+.cell.monster.goblin-wizard {
+  background-image: url("assets/images/goblin-wizard.png"), url("assets/images/floor-tile.png");
+}
+
 /* ---- Special unit glow effects ---- */
 .cell.elite {
   box-shadow: 0 0 8px rgba(244, 67, 54, 0.7);


### PR DESCRIPTION
## Summary
- add CSS rules for zombie, kobold, skeleton and goblin wizard sprites
- prevent text icon fallback for new monster sprites in renderDungeon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a3e4df584832787a7a3267e73c3a1