### PR TITLE
Implement corpse skip movement

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3392,8 +3392,12 @@ function killMonster(monster) {
                 const itemIndex = gameState.items.findIndex(i => i === item);
                 if (itemIndex !== -1) gameState.items.splice(itemIndex, 1);
             }
+            const dx = corpse.x - gameState.player.x;
+            const dy = corpse.y - gameState.player.y;
             gameState.dungeon[corpse.y][corpse.x] = 'corpse';
-            renderDungeon();
+            gameState.skipCorpsePanel = true;
+            movePlayer(dx, dy);
+            movePlayer(dx, dy);
         }
 
         function getMonsterRank(monster) {
@@ -5545,8 +5549,14 @@ function killMonster(monster) {
             if (cellType === 'corpse') {
                 const corpse = gameState.corpses.find(c => c.x === newX && c.y === newY);
                 if (corpse) {
-                    showCorpsePanel(corpse);
-                    return;
+                    if (gameState.skipCorpsePanel) {
+                        gameState.skipCorpsePanel = false;
+                        gameState.player.x = newX;
+                        gameState.player.y = newY;
+                    } else {
+                        showCorpsePanel(corpse);
+                        return;
+                    }
                 }
             }
             
@@ -7198,7 +7208,6 @@ function processTurn() {
             ignoreBtn.onclick = () => {
                 hideCorpsePanel();
                 ignoreCorpse(corpse);
-                processTurn();
             };
             content.appendChild(ignoreBtn);
 

--- a/src/state.js
+++ b/src/state.js
@@ -69,6 +69,7 @@
         camera: { x: 0, y: 0 },
         autoMovePath: null,
         autoMoveActive: false,
+        skipCorpsePanel: false,
         inventoryFilter: 'all',
         incubators: [null, null, null],
         hatchedSuperiors: [],

--- a/tests/ignoreCorpseMove.test.js
+++ b/tests/ignoreCorpseMove.test.js
@@ -1,0 +1,52 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createMonster, killMonster, ignoreCorpse, gameState } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.corpses = [];
+  gameState.items = [];
+
+  gameState.player.x = 0;
+  gameState.player.y = 1;
+
+  const monster = createMonster('GOBLIN', 1, 1, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[1][1] = 'monster';
+  killMonster(monster);
+
+  // ensure corpse recorded
+  if (!gameState.corpses.includes(monster) || gameState.dungeon[1][1] !== 'corpse') {
+    console.error('corpse not created');
+    process.exit(1);
+  }
+
+  ignoreCorpse(monster);
+
+  if (gameState.player.x !== 2 || gameState.player.y !== 1) {
+    console.error('player did not move past corpse');
+    process.exit(1);
+  }
+  if (gameState.dungeon[1][1] !== 'corpse') {
+    console.error('corpse removed after ignore');
+    process.exit(1);
+  }
+  if (gameState.turn !== 2) {
+    console.error('turn count not advanced twice');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- when ignoring a corpse move across it automatically
- support skipping corpse panel on next move
- test that ignoring corpse moves player two tiles and keeps the corpse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4389bf208327b27342b3b76d287b