### PR TITLE
Adjust map object emoji presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,67 +116,133 @@
             to { transform: scale(1.1); }
         }
         .treasure {
-            background: radial-gradient(circle, #FFD700, #FFC107);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #8B4513;
             box-shadow: 0 0 10px rgba(255, 215, 0, 0.7);
             animation: treasureSparkle 1s ease-in-out infinite alternate;
+            font-size: 20px;
         }
         @keyframes treasureSparkle {
             from { box-shadow: 0 0 10px rgba(255, 215, 0, 0.7); }
             to { box-shadow: 0 0 15px rgba(255, 215, 0, 1); }
         }
         .item {
-            background: radial-gradient(circle, #9575CD, #7E57C2);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: white;
             box-shadow: 0 0 6px rgba(149, 117, 205, 0.5);
+            font-size: 20px;
         }
         .chest {
-            background: radial-gradient(circle, #FFA726, #FB8C00);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #fff;
+            font-size: 20px;
         }
         .mine {
-            background: radial-gradient(circle, #795548, #5D4037);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #eee;
+            font-size: 20px;
         }
         .tree {
-            background: radial-gradient(circle, #388E3C, #2E7D32);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #e8f5e9;
+            font-size: 20px;
         }
         .bones {
-            background: radial-gradient(circle, #BDBDBD, #9E9E9E);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #fff;
+            font-size: 20px;
         }
         .temple {
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #fff;
+            font-size: 20px;
         }
-        .temple-heal { background: radial-gradient(circle, #00BCD4, #0097A7); }
-        .temple-food { background: radial-gradient(circle, #FF7043, #D84315); }
-        .temple-affinity { background: radial-gradient(circle, #BA68C8, #8E24AA); }
+        .temple-heal {
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
+            font-size: 20px;
+        }
+        .temple-food {
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
+            font-size: 20px;
+        }
+        .temple-affinity {
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
+            font-size: 20px;
+        }
         .plant {
-            background: radial-gradient(circle, #4CAF50, #2E7D32);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #e8f5e9;
             box-shadow: 0 0 6px rgba(76, 175, 80, 0.5);
+            font-size: 20px;
         }
         .projectile {
-            background: radial-gradient(circle, #ff9800, #e65100);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: white;
+            font-size: 20px;
         }
         .corpse {
-            background: radial-gradient(circle, #555, #333);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #ccc;
+            font-size: 20px;
         }
         .exit {
-            background: linear-gradient(45deg, #00BCD4, #00ACC1, #0097A7);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: white;
             box-shadow: 0 0 15px rgba(0, 188, 212, 0.8);
             animation: exitPortal 2s ease-in-out infinite;
-            font-size: 18px;
+            font-size: 20px;
             border: 2px solid #B2EBF2;
         }
         .shop {
-            background: linear-gradient(45deg, #ffeb3b, #ffc107);
+            background: none;
+            background-image: url('assets/images/floor-tile.png');
+            background-size: cover;
+            background-position: center;
             color: #333;
             font-weight: bold;
+            font-size: 20px;
         }
         @keyframes exitPortal {
             0% { 

--- a/style.css
+++ b/style.css
@@ -266,18 +266,22 @@
 
 /* 시체 셀 스타일 및 아이콘 표시 */
 .corpse {
-    background: radial-gradient(circle, #555, #333);
+    background: none;
+    background-image: url('assets/images/floor-tile.png');
+    background-size: cover;
+    background-position: center;
     color: #ccc;
     /* 텍스트 아이콘이 중앙에 오도록 flex 속성 추가 */
     display: flex;
     justify-content: center;
     align-items: center;
+    font-size: 20px;
 }
 
 /* BUG FIX: 시체 아이콘을 가상 요소로 렌더링하여 z-index 제어 */
 .cell.corpse::before {
     content: '☠️'; /* 표시할 아이콘 */
-    font-size: 20px; /* 아이콘 크기 조절 */
+    font-size: 24px; /* 아이콘 크기 조절 */
     position: absolute;
     /* z-index를 플레이어(10)보다 낮은 값으로 설정 */
     z-index: 1;


### PR DESCRIPTION
## Summary
- enlarge object emojis like items, shops and temples
- show floor tile image under these emojis
- update corpse emoji size and transparent background

## Testing
- `npm test` *(fails: monsterExp.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a45e96ac88327bce7377c3c82dc10