### PR TITLE
Fix BGM playback error

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -300,8 +300,7 @@ const BgmPlayer = {
         // 다음 트랙 인덱스로 이동, 마지막 트랙이었으면 0으로 돌아감 (나머지 연산자 %)
         this.currentTrackIndex = (this.currentTrackIndex + 1) % this.playlist.length;
 
-        // 현재 곡을 정지하고 다음 곡으로 교체
-        this.audioElement.pause();
+        // 현재 곡을 다음 곡으로 교체
         this.audioElement.src = this.playlist[this.currentTrackIndex];
 
         try {
@@ -342,12 +341,10 @@ function initializeAudio() {
         return;
     }
 
-    SoundEngine.initialize();
     try {
-        BgmPlayer.init();
-        BgmPlayer.play();
+        SoundEngine.initialize();
     } catch (err) {
-        console.error("BGM playback failed during initializeAudio", err);
+        console.error("Audio initialization failed", err);
     }
     
     isAudioInitialized = true;


### PR DESCRIPTION
## Summary
- prevent pause() from interrupting track changes
- avoid double initialization of BGM player

## Testing
- `npm test` *(fails: monsterExp.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a4758081483278371c3411f186281