### PR TITLE
Fix projectile log for ally monsters

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2077,8 +2077,10 @@ const MERCENARY_NAMES = [
                     const icon = proj.icon || '➡️';
                     const name = proj.skill ? SKILL_DEFS[proj.skill].name : '원거리 공격';
                     const detail = buildAttackDetail('원거리 공격', name, result);
+                    const msgType = attacker === gameState.player ? 'combat' : 'mercenary';
+                    const attackerPart = attacker === gameState.player ? '' : `${attacker.name}이(가) `;
                     if (!result.hit) {
-                        addMessage(`❌ ${monster.name}에게 ${name}이 빗나갔습니다!`, 'combat', detail);
+                        addMessage(`❌ ${attackerPart}${monster.name}에게 ${name}이 빗나갔습니다!`, msgType, detail);
                     } else {
                         const critMsg = result.crit ? ' (치명타!)' : '';
                         let dmgStr = formatNumber(result.baseDamage);
@@ -2086,7 +2088,7 @@ const MERCENARY_NAMES = [
                             const emoji = ELEMENT_EMOJI[result.element] || '';
                             dmgStr = `${formatNumber(result.baseDamage)}+${emoji}${formatNumber(result.elementDamage)}`;
                         }
-                        addMessage(`${icon} ${monster.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, 'combat', detail);
+                        addMessage(`${icon} ${attackerPart}${monster.name}에게 ${dmgStr}의 피해를 입혔습니다${critMsg}!`, msgType, detail);
                     }
 
                     // --- BUG FIX START ---


### PR DESCRIPTION
## Summary
- improve combat messages for projectiles so mercenary attackers are shown in the log
- ensure ranged attacks from revived monsters display correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a47bde3c08327a3ab00813f116709