### PR TITLE
Add mercenary item swap test

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5344,6 +5344,22 @@ function killMonster(monster) {
                 const oldY = gameState.player.y;
                 gameState.player.x = newX;
                 gameState.player.y = newY;
+
+                if (cellType === 'item') {
+                    const item = gameState.items.find(i => i.x === newX && i.y === newY);
+                    if (item) {
+                        addToInventory(item);
+                        SoundEngine.playSound('getItem');
+                        addMessage(`📦 ${item.name}을(를) 획득했습니다!`, 'item');
+
+                        const itemIndex = gameState.items.findIndex(i => i === item);
+                        if (itemIndex !== -1) {
+                            gameState.items.splice(itemIndex, 1);
+                        }
+                        gameState.dungeon[newY][newX] = 'empty';
+                    }
+                }
+
                 blockingMercenary.x = oldX;
                 blockingMercenary.y = oldY;
                 processTurn();

--- a/tests/mercenaryItemSwap.test.js
+++ b/tests/mercenaryItemSwap.test.js
@@ -1,0 +1,48 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createMercenary, createItem, movePlayer, gameState } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.items = [];
+  gameState.activeMercenaries = [];
+
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+
+  const item = createItem('shortSword', 2, 1);
+  gameState.items.push(item);
+  gameState.dungeon[1][2] = 'item';
+
+  const merc = createMercenary('WARRIOR', 2, 1);
+  gameState.activeMercenaries.push(merc);
+
+  movePlayer(1, 0);
+
+  if (!gameState.player.inventory.includes(item)) {
+    console.error('item not added to inventory');
+    process.exit(1);
+  }
+  if (gameState.items.length !== 0) {
+    console.error('item not removed from items list');
+    process.exit(1);
+  }
+  if (merc.x !== 1 || merc.y !== 1) {
+    console.error('mercenary did not swap with player');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- when the player swaps places with a mercenary standing on an item tile, collect the item
- add `mercenaryItemSwap.test.js` covering this interaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4906da988327878c011c2ad8fc79