### PR TITLE
Refactor corpse ignoring logic

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -69,7 +69,6 @@
         camera: { x: 0, y: 0 },
         autoMovePath: null,
         autoMoveActive: false,
-        skipCorpsePanel: false,
         inventoryFilter: 'all',
         incubators: [null, null, null],
         hatchedSuperiors: [],

--- a/tests/ignoreCorpseMove.test.js
+++ b/tests/ignoreCorpseMove.test.js
@@ -9,7 +9,7 @@ async function run() {
   win.updateCamera = () => {};
   win.requestAnimationFrame = fn => fn();
 
-  const { createMonster, killMonster, ignoreCorpse, gameState } = win;
+  const { createMonster, killMonster, ignoreCorpse, processTurn, findAdjacentEmpty, gameState } = win;
 
   const size = 3;
   gameState.dungeonSize = size;
@@ -34,17 +34,19 @@ async function run() {
   }
 
   ignoreCorpse(monster);
+  processTurn();
 
-  if (gameState.player.x !== 2 || gameState.player.y !== 1) {
-    console.error('player did not move past corpse');
+  const expected = findAdjacentEmpty(1, 1);
+  if (gameState.player.x !== expected.x || gameState.player.y !== expected.y) {
+    console.error('player not moved to adjacent empty tile');
     process.exit(1);
   }
-  if (gameState.dungeon[1][1] !== 'corpse') {
-    console.error('corpse removed after ignore');
+  if (gameState.dungeon[1][1] !== 'empty') {
+    console.error('corpse not removed after ignore');
     process.exit(1);
   }
-  if (gameState.turn !== 2) {
-    console.error('turn count not advanced twice');
+  if (gameState.turn !== 1) {
+    console.error('turn count should increase once');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- revise `ignoreCorpse` behaviour
- drop `skipCorpsePanel` state usage
- update corpse panel logic and movement handling
- adjust tests for new ignore behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4d09c20c8327a720542cd8960092