### PR TITLE
Fix killMonster item drop on blocked tiles

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3195,6 +3195,7 @@ function findNearestEmpty(x, y) {
         }
 
 function killMonster(monster) {
+            let itemOnCorpse = false;
             SoundEngine.playSound('monsterDie'); // 몬스터 사망음 재생
             addMessage(`💀 ${monster.name}을(를) 처치했습니다!`, 'combat');
             gameState.player.exp += monster.exp;
@@ -3210,6 +3211,9 @@ function killMonster(monster) {
                 if (eq.length) {
                     const drop = eq[Math.floor(Math.random() * eq.length)];
                     const pos = findAdjacentEmpty(monster.x, monster.y);
+                    if (pos.x === monster.x && pos.y === monster.y) {
+                        itemOnCorpse = true;
+                    }
                     drop.x = pos.x;
                     drop.y = pos.y;
                     gameState.items.push(drop);
@@ -3220,6 +3224,9 @@ function killMonster(monster) {
                 if (Math.random() < 0.2) bossItems.push('reviveScroll');
                 const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
                 const pos = findAdjacentEmpty(monster.x, monster.y);
+                if (pos.x === monster.x && pos.y === monster.y) {
+                    itemOnCorpse = true;
+                }
                 const bossItem = createItem(bossItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
                 gameState.items.push(bossItem);
                 gameState.dungeon[pos.y][pos.x] = 'item';
@@ -3239,6 +3246,9 @@ function killMonster(monster) {
                         randomItemKey = 'reviveScroll';
                     }
                     const pos = findAdjacentEmpty(monster.x, monster.y);
+                    if (pos.x === monster.x && pos.y === monster.y) {
+                        itemOnCorpse = true;
+                    }
                     const droppedItem = createItem(randomItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
                     gameState.items.push(droppedItem);
                     gameState.dungeon[pos.y][pos.x] = 'item';
@@ -3248,6 +3258,9 @@ function killMonster(monster) {
             const unknown = Object.keys(RECIPES).filter(r => !gameState.knownRecipes.includes(r));
             if (!monster.isChampion && unknown.length && Math.random() < 0.25) {
                 const pos = findAdjacentEmpty(monster.x, monster.y);
+                if (pos.x === monster.x && pos.y === monster.y) {
+                    itemOnCorpse = true;
+                }
                 const scroll = createRecipeScroll(unknown[Math.floor(Math.random() * unknown.length)], pos.x, pos.y);
                 gameState.items.push(scroll);
                 gameState.dungeon[pos.y][pos.x] = 'item';
@@ -3257,7 +3270,7 @@ function killMonster(monster) {
             monster.health = 0;
             monster.turnsLeft = CORPSE_TURNS;
             gameState.corpses.push(monster);
-            gameState.dungeon[monster.y][monster.x] = 'corpse';
+            gameState.dungeon[monster.y][monster.x] = itemOnCorpse ? 'item' : 'corpse';
         }
 
         function convertMonsterToMercenary(monster) {

--- a/tests/itemDropNoSpace.test.js
+++ b/tests/itemDropNoSpace.test.js
@@ -1,0 +1,47 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createChampion, createItem, killMonster, gameState } = win;
+
+  const champ = createChampion('ARCHER', 1, 1, 1);
+  champ.equipped.weapon = createItem('shortSword', 0, 0);
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('wall'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [champ];
+  gameState.items = [];
+  gameState.corpses = [];
+  gameState.dungeon[1][1] = 'monster';
+
+  killMonster(champ);
+
+  if (gameState.items.length !== 1) {
+    console.error('item not dropped');
+    process.exit(1);
+  }
+  const item = gameState.items[0];
+  if (item.x !== 1 || item.y !== 1) {
+    console.error('item not on corpse tile');
+    process.exit(1);
+  }
+  if (gameState.dungeon[1][1] !== 'item') {
+    console.error('corpse tile not marked item');
+    process.exit(1);
+  }
+  if (!gameState.corpses.includes(champ)) {
+    console.error('corpse not recorded');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- update `killMonster` to handle items when no adjacent tile is free
- set corpse tile to `item` when necessary
- add test for item drop when adjacent cells are blocked

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a50496e488327be9bf512d18eed77