### PR TITLE
Add sound cue for stat allocation

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3771,6 +3771,7 @@ function killMonster(monster) {
         function allocateStat(stat) {
             if (gameState.player.statPoints <= 0) return;
             if (!['strength','agility','endurance','focus','intelligence'].includes(stat)) return;
+            SoundEngine.playSound('statAllocate');
             gameState.player[stat] += 1;
             gameState.player.statPoints -= 1;
             updateStats();


### PR DESCRIPTION
## Summary
- play stat allocation sound effect in allocateStat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a516438148327aa0a144f4fe0df75