### PR TITLE
Add BGM control buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The full roster of monsters appears on progressively higher floors as defined in
 - Use the arrow keys or on-screen arrows to move your character.
 - Press `Z` (or `F`) or click **Attack** to strike the nearest monster.
 - Number keys `1`-`9` open the details of each hired mercenary.
+- Use the BGM buttons at the top of the page to switch tracks or mute the background music.
 - Additional actions such as **Heal**, **Recall**, **Skill1** and **Skill2** are available via the action buttons. You can also use `X` for **Skill1**, `C` for **Skill2**, `V` for **Ranged** attack and `A` to recall your mercenaries.
 
 ### Hiring Mercenaries

--- a/index.html
+++ b/index.html
@@ -815,6 +815,11 @@
 </head>
 <body>
     <h1>🏰 던전 크롤러 🗡️</h1>
+    <div class="top-controls">
+        <button id="prev-bgm">⏮️ 이전</button>
+        <button id="toggle-bgm">🔇 배경음</button>
+        <button id="next-bgm">다음 ⏭️</button>
+    </div>
     <div id="turn-effects" class="turn-effects"></div>
     <div class="main-container">
         <div class="game-area">

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -317,6 +317,25 @@ const BgmPlayer = {
         }
     },
 
+    /**
+     * 이전 트랙을 재생합니다. 첫 번째 트랙에서 호출되면 마지막 곡으로 이동합니다.
+     */
+    async playPreviousTrack() {
+        this.currentTrackIndex = (this.currentTrackIndex - 1 + this.playlist.length) % this.playlist.length;
+        this.audioElement.src = this.playlist[this.currentTrackIndex];
+        try {
+            await this.audioElement.play();
+        } catch (err) {
+            console.error('BGM playback failed', err);
+        }
+    },
+
+    /** 배경음 음소거 상태를 토글합니다 */
+    toggleMute() {
+        if (!this.audioElement) return;
+        this.audioElement.muted = !this.audioElement.muted;
+    },
+
     // 재생 시작 함수 수정
     async play() {
         if (!this.isInitialized || !this.audioElement) return;
@@ -7453,6 +7472,14 @@ function processTurn() {
         });
         document.getElementById('close-crafting-detail').onclick = hideCraftingDetailPanel;
         document.getElementById('close-corpse-panel').onclick = hideCorpsePanel;
+
+        // BGM control buttons
+        const nextBtn = document.getElementById('next-bgm');
+        if (nextBtn) nextBtn.onclick = () => { initializeAudio(); BgmPlayer.playNextTrack(); };
+        const prevBtn = document.getElementById('prev-bgm');
+        if (prevBtn) prevBtn.onclick = () => { initializeAudio(); BgmPlayer.playPreviousTrack(); };
+        const toggleBtn = document.getElementById('toggle-bgm');
+        if (toggleBtn) toggleBtn.onclick = () => { initializeAudio(); BgmPlayer.toggleMute(); };
 
         document.addEventListener('keydown', (e) => {
             initializeAudio();


### PR DESCRIPTION
## Summary
- include BGM controls at the top of the page
- allow cycling through tracks and muting background music
- document new controls in the README

## Testing
- `npm test` *(fails: monsterExp.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684a51c60e90832785c19a2da3daea47