### PR TITLE
Fix corpse rendering

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3687,7 +3687,9 @@ function killMonster(monster) {
                             } else if (baseCellType === 'altar') {
                                 div.textContent = '🗺️';
                             } else if (baseCellType === 'corpse') {
-                                // div.textContent = '☠️';
+                                const corpse = gameState.corpses.find(c => c.x === x && c.y === y);
+                                div.textContent = (corpse && corpse.icon) ? corpse.icon : '💀';
+                                finalClasses.push('corpse');
                             } else if (baseCellType === 'treasure') {
                                 div.textContent = '💰';
                             } else if (baseCellType === 'exit') {

--- a/style.css
+++ b/style.css
@@ -280,13 +280,8 @@
 
 /* BUG FIX: 시체 아이콘을 가상 요소로 렌더링하여 z-index 제어 */
 .cell.corpse::before {
-    content: '☠️'; /* 표시할 아이콘 */
-    font-size: 24px; /* 아이콘 크기 조절 */
-    position: absolute;
-    /* z-index를 플레이어(10)보다 낮은 값으로 설정 */
-    z-index: 1;
-    /* 텍스트가 마우스 이벤트를 방해하지 않도록 설정 */
-    pointer-events: none;
+    content: '';
+    display: none;
 }
 /* style.css */
 

--- a/tests/corpseIcon.test.js
+++ b/tests/corpseIcon.test.js
@@ -1,0 +1,45 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.updateSkillDisplay = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    createMonster,
+    killMonster,
+    rebuildDungeonDOM,
+    renderDungeon,
+    gameState
+  } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+
+  rebuildDungeonDOM();
+
+  gameState.player.x = 0;
+  gameState.player.y = 0;
+
+  const monster = createMonster('ZOMBIE', 1, 1, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[1][1] = 'monster';
+
+  killMonster(monster);
+
+  renderDungeon();
+
+  const cell = gameState.cellElements[1][1];
+  if (!cell.className.includes('corpse') || cell.textContent !== monster.icon) {
+    console.error('corpse icon not rendered');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- render monster corpses with their icon when drawing the dungeon
- remove skull forced via CSS
- test corpse icon rendering

## Testing
- `node runTests.js` *(fails: mana.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_684a504a96108327a9044406bbbe5833