### PR TITLE
Handle dead homing projectile targets

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2051,6 +2051,9 @@ const MERCENARY_NAMES = [
         function processProjectiles() {
             const remaining = [];
             for (const proj of gameState.projectiles) {
+                if (proj.homing && proj.target && proj.target.health <= 0) {
+                    continue;
+                }
                 if (proj.homing && proj.target) {
                     proj.dx = Math.sign(proj.target.x - proj.x);
                     proj.dy = Math.sign(proj.target.y - proj.y);

--- a/tests/projectileTargetDeath.test.js
+++ b/tests/projectileTargetDeath.test.js
@@ -1,0 +1,36 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    gameState,
+    createMonster,
+    createHomingProjectile,
+    processProjectiles,
+    killMonster
+  } = win;
+
+  const monster = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+  gameState.dungeon[monster.y][monster.x - 1] = 'empty';
+
+  createHomingProjectile(gameState.player.x, gameState.player.y, monster);
+  killMonster(monster);
+  processProjectiles();
+
+  if (gameState.projectiles.length !== 0) {
+    console.error('projectile should be removed when target dies');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- ignore homing projectiles whose targets are already dead
- add regression test for projectiles removed when target dies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a504c9c808327a9e439c453fcda1f