### PR TITLE
Fix playlist commas

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -288,10 +288,10 @@ const BgmPlayer = {
         'assets/audio/bgm6.mp3',
         'assets/audio/bgm7.mp3',
         'assets/audio/bgm8.mp3',
-        'assets/audio/bgm9.mp3'
-        'assets/audio/bgm10.mp3'
-        'assets/audio/bgm11.mp3'
-        'assets/audio/bgm12.mp3'
+        'assets/audio/bgm9.mp3',
+        'assets/audio/bgm10.mp3',
+        'assets/audio/bgm11.mp3',
+        'assets/audio/bgm12.mp3',
         'assets/audio/bgm13.mp3'
     ],
     // [추가] 현재 재생 중인 트랙의 인덱스


### PR DESCRIPTION
## Summary
- fix missing commas in `SoundEngine.playlist`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a586686e48327a0d194120c838be8