### PR TITLE
Stub rollDice for status effects test

### DIFF
--- a/tests/statusEffects.test.js
+++ b/tests/statusEffects.test.js
@@ -9,6 +9,10 @@ async function run() {
   win.updateCamera = () => {};
   win.requestAnimationFrame = fn => fn();
 
+  // Stub rollDice so status effects always apply
+  const originalRoll = win.rollDice;
+  win.rollDice = () => 20;
+
   const { tryApplyStatus, movePlayer, skill1Action, purifyTarget, applyStatusEffects, gameState } = win;
 
   const size = 3;
@@ -51,6 +55,9 @@ async function run() {
     console.error('purify did not remove status');
     process.exit(1);
   }
+
+  // Restore original rollDice implementation
+  win.rollDice = originalRoll;
 
   console.log('status ok');
 }


### PR DESCRIPTION
## Summary
- mock `rollDice` in `statusEffects.test.js` so status application is deterministic
- restore the original function at the end of the test

## Testing
- `node tests/statusEffects.test.js`
- `npm test` *(fails: took too long to run all tests in environment)*

------
https://chatgpt.com/codex/tasks/task_e_684a674d69c08327acac5a1ea18a7642