### PR TITLE
Support trophy & artifact slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,6 +879,8 @@
                     <div class="equipped-slot" id="equipped-armor">방어구: 없음</div>
                     <div class="equipped-slot" id="equipped-accessory1">악세서리1: 없음</div>
                     <div class="equipped-slot" id="equipped-accessory2">악세서리2: 없음</div>
+                    <div class="equipped-slot" id="equipped-trophy">트로피: 없음</div>
+                    <div class="equipped-slot" id="equipped-artifact">아티팩트: 없음</div>
                 </div>
                 <h3>📦 보유 아이템</h3>
                                 <div id="inventory-filters" style="margin-bottom: 10px; display: flex; flex-wrap: wrap; gap: 5px;">
@@ -941,6 +943,8 @@
                 <div>⭐ 경험치: <span id="exp">0</span>/<span id="expNeeded">20</span></div>
                 <div>💰 골드: <span id="gold">0</span></div>
                 <div>🏰 층: <span id="floor">1</span></div>
+                <div id="equipped-trophy-side">트로피: 없음</div>
+                <div id="equipped-artifact-side">아티팩트: 없음</div>
             </div>
             
             <div class="mercenary-panel">

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -407,6 +407,8 @@ const ITEM_TYPES = {
             WEAPON: 'weapon',
             ARMOR: 'armor',
             ACCESSORY: 'accessory',
+            TROPHY: 'trophy',
+            ARTIFACT: 'artifact',
             POTION: 'potion',
             REVIVE: 'revive',
             EXP_SCROLL: 'expScroll',
@@ -419,7 +421,7 @@ const ITEM_TYPES = {
         };
 
 const INVENTORY_CATEGORIES = {
-    equipment: [ITEM_TYPES.WEAPON, ITEM_TYPES.ARMOR, ITEM_TYPES.ACCESSORY],
+    equipment: [ITEM_TYPES.WEAPON, ITEM_TYPES.ARMOR, ITEM_TYPES.ACCESSORY, ITEM_TYPES.TROPHY, ITEM_TYPES.ARTIFACT],
     recipe: [ITEM_TYPES.RECIPE_SCROLL],
     food: [ITEM_TYPES.FOOD],
     potion: [ITEM_TYPES.POTION, ITEM_TYPES.REVIVE],
@@ -1361,6 +1363,16 @@ const MERCENARY_NAMES = [
                 type: ITEM_TYPES.MAP,
                 level: 2,
                 icon: '🗺️'
+            },
+            testTrophy: {
+                name: '🏆 테스트 트로피',
+                type: ITEM_TYPES.TROPHY,
+                icon: '🏆'
+            },
+            testArtifact: {
+                name: '🔮 테스트 아티팩트',
+                type: ITEM_TYPES.ARTIFACT,
+                icon: '🔮'
             }
 
         };
@@ -1750,7 +1762,7 @@ const MERCENARY_NAMES = [
         function getStatusResist(character, status) {
             let value = character.statusResistances && character.statusResistances[status] ? character.statusResistances[status] : 0;
             if (character.equipped) {
-                ['weapon', 'armor', 'accessory1', 'accessory2', 'tile'].forEach(slot => {
+                ['weapon', 'armor', 'accessory1', 'accessory2', 'trophy', 'artifact', 'tile'].forEach(slot => {
                     const it = character.equipped[slot];
                     if (it && it[status + 'Resist'] !== undefined) {
                         value += it[status + 'Resist'];
@@ -2037,7 +2049,7 @@ const MERCENARY_NAMES = [
                 if (character.equipped.tile && character.equipped.tile.effects && character.equipped.tile.effects[stat]) {
                     value += character.equipped.tile.effects[stat];
                 }
-                ['weapon', 'armor', 'accessory1', 'accessory2'].forEach(slot => {
+                ['weapon', 'armor', 'accessory1', 'accessory2', 'trophy', 'artifact'].forEach(slot => {
                     const it = character.equipped[slot];
                     if (it && it[stat] !== undefined) {
                         value += it[stat];
@@ -2249,6 +2261,26 @@ const MERCENARY_NAMES = [
                 acc2Slot.textContent = '악세서리2: 없음';
                 acc2Slot.onclick = null;
             }
+            const trophySlot = document.getElementById('equipped-trophy');
+            if (trophySlot) {
+                if (gameState.player.equipped.trophy) {
+                    trophySlot.textContent = `트로피: ${formatItem(gameState.player.equipped.trophy)}`;
+                    trophySlot.onclick = () => unequipAccessory('trophy');
+                } else {
+                    trophySlot.textContent = '트로피: 없음';
+                    trophySlot.onclick = null;
+                }
+            }
+            const artifactSlot = document.getElementById('equipped-artifact');
+            if (artifactSlot) {
+                if (gameState.player.equipped.artifact) {
+                    artifactSlot.textContent = `아티팩트: ${formatItem(gameState.player.equipped.artifact)}`;
+                    artifactSlot.onclick = () => unequipAccessory('artifact');
+                } else {
+                    artifactSlot.textContent = '아티팩트: 없음';
+                    artifactSlot.onclick = null;
+                }
+            }
             const tileSlot = document.getElementById('equipped-tile');
             if (tileSlot) {
                 if (gameState.player.equipped.tile) {
@@ -2441,6 +2473,8 @@ function updateMaterialsDisplay() {
                 const armor = merc.equipped && merc.equipped.armor ? merc.equipped.armor.name : '없음';
                 const accessory1 = merc.equipped && merc.equipped.accessory1 ? merc.equipped.accessory1.name : '없음';
                 const accessory2 = merc.equipped && merc.equipped.accessory2 ? merc.equipped.accessory2.name : '없음';
+                const trophy = merc.equipped && merc.equipped.trophy ? merc.equipped.trophy.name : '없음';
+                const artifact = merc.equipped && merc.equipped.artifact ? merc.equipped.artifact.name : '없음';
             const totalAttack = formatNumber(getStat(merc, 'attack'));
             const totalDefense = formatNumber(getStat(merc, 'defense'));
                 const skillInfo = MERCENARY_SKILLS[merc.skill] || MONSTER_SKILLS[merc.skill];
@@ -2450,7 +2484,7 @@ function updateMaterialsDisplay() {
 
                 div.textContent = `${formatNumber(i + 1)}. ${merc.icon} ${merc.name} Lv.${formatNumber(merc.level)} (HP:${hp}, MP:${mp}) ` +
                     `[공격:${totalAttack}, 방어:${totalDefense}] ` +
-                    `[무기:${weapon}, 방어구:${armor}, 악세1:${accessory1}, 악세2:${accessory2}] ` +
+                    `[무기:${weapon}, 방어구:${armor}, 악세1:${accessory1}, 악세2:${accessory2}, 트로피:${trophy}, 아티:${artifact}] ` +
                     `[${skillText}]`;
 
                 if (merc.alive) {
@@ -2558,6 +2592,8 @@ function updateMaterialsDisplay() {
             const armor = merc.equipped && merc.equipped.armor ? merc.equipped.armor.name : '없음';
             const accessory1 = merc.equipped && merc.equipped.accessory1 ? merc.equipped.accessory1.name : '없음';
             const accessory2 = merc.equipped && merc.equipped.accessory2 ? merc.equipped.accessory2.name : '없음';
+            const trophy = merc.equipped && merc.equipped.trophy ? merc.equipped.trophy.name : '없음';
+            const artifact = merc.equipped && merc.equipped.artifact ? merc.equipped.artifact.name : '없음';
 
             const weaponBtn = merc.equipped && merc.equipped.weapon
                 ? `<button class="sell-button" onclick="unequipItemFromMercenary('${merc.id}','weapon')">해제</button>`
@@ -2570,6 +2606,12 @@ function updateMaterialsDisplay() {
                 : '';
             const acc2Btn = merc.equipped && merc.equipped.accessory2
                 ? `<button class="sell-button" onclick="unequipItemFromMercenary('${merc.id}','accessory2')">해제</button>`
+                : '';
+            const trophyBtn = merc.equipped && merc.equipped.trophy
+                ? `<button class="sell-button" onclick="unequipItemFromMercenary('${merc.id}','trophy')">해제</button>`
+                : '';
+            const artifactBtn = merc.equipped && merc.equipped.artifact
+                ? `<button class="sell-button" onclick="unequipItemFromMercenary('${merc.id}','artifact')">해제</button>`
                 : '';
             const skills = [merc.skill, merc.skill2].filter(Boolean);
             const skillHtml = skills.map(key => {
@@ -2617,6 +2659,8 @@ function updateMaterialsDisplay() {
                 <div>방어구: ${armor} ${armorBtn}</div>
                 <div>악세1: ${accessory1} ${acc1Btn}</div>
                 <div>악세2: ${accessory2} ${acc2Btn}</div>
+                <div>트로피: ${trophy} ${trophyBtn}</div>
+                <div>아티팩트: ${artifact} ${artifactBtn}</div>
                 ${skillHtml || '<div>스킬: 없음</div>'}
                 <div>${actionBtn}</div>
             `;
@@ -2744,6 +2788,8 @@ function updateMaterialsDisplay() {
             const armor = eq.armor ? eq.armor.name : '없음';
             const acc1 = eq.accessory1 ? eq.accessory1.name : '없음';
             const acc2 = eq.accessory2 ? eq.accessory2.name : '없음';
+            const trophy = eq.trophy ? eq.trophy.name : '없음';
+            const artifact = eq.artifact ? eq.artifact.name : '없음';
             const skillInfo = champion.monsterSkill ? MONSTER_SKILLS[champion.monsterSkill] : null;
             const skillLine = skillInfo ? `<div>스킬: ${skillInfo.icon} ${skillInfo.name}</div>` : '<div>스킬: 없음</div>';
             const html = `
@@ -2770,6 +2816,8 @@ function updateMaterialsDisplay() {
                 <div>방어구: ${armor}</div>
                 <div>악세1: ${acc1}</div>
                 <div>악세2: ${acc2}</div>
+                <div>트로피: ${trophy}</div>
+                <div>아티팩트: ${artifact}</div>
                 ${skillLine}
             `;
             document.getElementById('monster-detail-content').innerHTML = html;
@@ -2869,6 +2917,26 @@ function updateMaterialsDisplay() {
                 } else {
                     tileSlot.textContent = '타일: 없음';
                     tileSlot.onclick = null;
+                }
+            }
+            const trophySide = document.getElementById('equipped-trophy-side');
+            if (trophySide) {
+                if (gameState.player.equipped.trophy) {
+                    trophySide.textContent = `트로피: ${formatItem(gameState.player.equipped.trophy)}`;
+                    trophySide.onclick = () => unequipAccessory('trophy');
+                } else {
+                    trophySide.textContent = '트로피: 없음';
+                    trophySide.onclick = null;
+                }
+            }
+            const artifactSide = document.getElementById('equipped-artifact-side');
+            if (artifactSide) {
+                if (gameState.player.equipped.artifact) {
+                    artifactSide.textContent = `아티팩트: ${formatItem(gameState.player.equipped.artifact)}`;
+                    artifactSide.onclick = () => unequipAccessory('artifact');
+                } else {
+                    artifactSide.textContent = '아티팩트: 없음';
+                    artifactSide.onclick = null;
                 }
             }
             document.getElementById('weaponBonus').textContent = gameState.player.equipped.weapon ? `(+${formatNumber(gameState.player.equipped.weapon.attack)})` : '';
@@ -3096,7 +3164,8 @@ function updateMaterialsDisplay() {
                 statusEffect: data.statusEffect,
                 lootChance: 0.3,
                 fullness: 75,
-                hasActed: false
+                hasActed: false,
+                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null, trophy: null, artifact: null }
             };
             setMonsterLevel(monster, level);
             monster.skillLevels = {};
@@ -3419,7 +3488,7 @@ function killMonster(monster) {
                 affinity: 30,
                 fullness: 75,
                 hasActed: false,
-                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null },
+                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null, trophy: null, artifact: null },
                 range: monster.range,
                 special: monster.special,
                 trait: monster.trait || null,
@@ -4572,7 +4641,9 @@ function killMonster(monster) {
                     armor: null,
                     accessory1: null,
                     accessory2: null,
-                    tile: null
+                    tile: null,
+                    trophy: null,
+                    artifact: null
                 }
             };
         }
@@ -4725,7 +4796,7 @@ function killMonster(monster) {
                 lootChance: 1,
                 hasActed: false,
                 isChampion: true,
-                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null },
+                equipped: { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null, trophy: null, artifact: null },
                 elementResistances: {fire:0, ice:0, lightning:0, earth:0, light:0, dark:0},
                 statusResistances: {poison:0, bleed:0, burn:0, freeze:0, paralysis:0, nightmare:0, silence:0, petrify:0, debuff:0},
                 poison:false,burn:false,freeze:false,bleed:false,
@@ -5005,6 +5076,18 @@ function killMonster(monster) {
                 }
                 gameState.player.equipped[slot] = item;
                 addMessage(`💍 ${item.name}을(를) 장착했습니다.`, 'item');
+            } else if (item.type === ITEM_TYPES.TROPHY) {
+                if (gameState.player.equipped.trophy) {
+                    addToInventory(gameState.player.equipped.trophy);
+                }
+                gameState.player.equipped.trophy = item;
+                addMessage(`🏆 ${item.name}을(를) 장착했습니다.`, 'item');
+            } else if (item.type === ITEM_TYPES.ARTIFACT) {
+                if (gameState.player.equipped.artifact) {
+                    addToInventory(gameState.player.equipped.artifact);
+                }
+                gameState.player.equipped.artifact = item;
+                addMessage(`🔮 ${item.name}을(를) 장착했습니다.`, 'item');
             }
             
             const index = gameState.player.inventory.findIndex(i => i.id === item.id);
@@ -5055,7 +5138,10 @@ function killMonster(monster) {
         function equipTile(tile, unit) {
             SoundEngine.playSound('equipItem');
             if (!unit.equipped) {
-                unit.equipped = { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null };
+                unit.equipped = { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null, trophy: null, artifact: null };
+            } else {
+                if (!('trophy' in unit.equipped)) unit.equipped.trophy = null;
+                if (!('artifact' in unit.equipped)) unit.equipped.artifact = null;
             }
             if (unit.equipped.tile) {
                 addToInventory(unit.equipped.tile);
@@ -5088,7 +5174,10 @@ function killMonster(monster) {
         function equipItemToMercenary(item, mercenary) {
             // 용병 장비 초기화 확인
             if (!mercenary.equipped) {
-                mercenary.equipped = { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null };
+                mercenary.equipped = { weapon: null, armor: null, accessory1: null, accessory2: null, tile: null, trophy: null, artifact: null };
+            } else {
+                if (!('trophy' in mercenary.equipped)) mercenary.equipped.trophy = null;
+                if (!('artifact' in mercenary.equipped)) mercenary.equipped.artifact = null;
             }
             
             if (item.type === ITEM_TYPES.WEAPON) {
@@ -5115,6 +5204,18 @@ function killMonster(monster) {
                 }
                 mercenary.equipped[slot] = item;
                 addMessage(`💍 ${mercenary.name}이(가) ${item.name}을(를) 장착했습니다.`, 'mercenary');
+            } else if (item.type === ITEM_TYPES.TROPHY) {
+                if (mercenary.equipped.trophy) {
+                    addToInventory(mercenary.equipped.trophy);
+                }
+                mercenary.equipped.trophy = item;
+                addMessage(`🏆 ${mercenary.name}이(가) ${item.name}을(를) 장착했습니다.`, 'mercenary');
+            } else if (item.type === ITEM_TYPES.ARTIFACT) {
+                if (mercenary.equipped.artifact) {
+                    addToInventory(mercenary.equipped.artifact);
+                }
+                mercenary.equipped.artifact = item;
+                addMessage(`🔮 ${mercenary.name}이(가) ${item.name}을(를) 장착했습니다.`, 'mercenary');
             }
             
             const index = gameState.player.inventory.findIndex(i => i.id === item.id);
@@ -6869,10 +6970,14 @@ function processTurn() {
                         armor: null,
                         accessory1: null,
                         accessory2: null,
-                        tile: null
+                        tile: null,
+                        trophy: null,
+                        artifact: null
                     };
-                } else if (!('tile' in m.equipped)) {
-                    m.equipped.tile = null;
+                } else {
+                    if (!('tile' in m.equipped)) m.equipped.tile = null;
+                    if (!('trophy' in m.equipped)) m.equipped.trophy = null;
+                    if (!('artifact' in m.equipped)) m.equipped.artifact = null;
                 }
             };
 

--- a/src/state.js
+++ b/src/state.js
@@ -35,7 +35,9 @@
                 armor: null,
                 accessory1: null,
                 accessory2: null,
-                tile: null
+                tile: null,
+                trophy: null,
+                artifact: null
             },
             inventory: [],
             tileInventory: [],

--- a/tests/equipmentSlots.test.js
+++ b/tests/equipmentSlots.test.js
@@ -1,0 +1,40 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, createMercenary, createChampion, createMonster, convertMonsterToMercenary } = win;
+
+  if (!('trophy' in gameState.player.equipped) || !('artifact' in gameState.player.equipped)) {
+    console.error('player slots missing');
+    process.exit(1);
+  }
+
+  const merc = createMercenary('WARRIOR', 0, 0);
+  if (!('trophy' in merc.equipped) || !('artifact' in merc.equipped)) {
+    console.error('mercenary slots missing');
+    process.exit(1);
+  }
+
+  const champ = createChampion('WARRIOR', 0, 0, 1);
+  if (!('trophy' in champ.equipped) || !('artifact' in champ.equipped)) {
+    console.error('champion slots missing');
+    process.exit(1);
+  }
+
+  const mon = createMonster('ZOMBIE', 0, 0, 1);
+  const conv = convertMonsterToMercenary(mon);
+  if (!('trophy' in conv.equipped) || !('artifact' in conv.equipped)) {
+    console.error('converted monster slots missing');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add TROPHY and ARTIFACT item types
- give player and units trophy/artifact equipment slots
- ensure save/load initializes new slots
- extend equipment management for new slots
- display trophy/artifact in UI
- add placeholder items
- test new slot creation

## Testing
- `node runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684a75149e788327a7b936b909653e77