### PR TITLE
Remove spawnStartingRecipes usage

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7663,7 +7663,6 @@ function processTurn() {
             for (let i = 0; i < 5; i++) {
                 gameState.player.inventory.push(createItem('smallExpScroll', 0, 0));
             }
-            spawnStartingRecipes();
             spawnStartingMaps();
             updateInventoryDisplay();
             updateSkillDisplay();
@@ -7799,7 +7798,7 @@ removeEggFromIncubator, renderDungeon, reviveMercenary, reviveMonsterCorpse,
  rollDice, saveGame, sellItem, confirmAndSell, enhanceItem, disassembleItem, setMercenaryLevel, setMonsterLevel, setChampionLevel,
 showChampionDetails, showItemDetailPanel, showItemTargetPanel, showMercenaryDetails,
 showMonsterDetails, showShop, showSkillDamage, showAuraDetails, skill1Action, skill2Action,
-spawnMercenaryNearPlayer, spawnStartingRecipes, spawnStartingMaps, startGame, swapActiveAndStandby, tryApplyStatus,
+spawnMercenaryNearPlayer, spawnStartingMaps, startGame, swapActiveAndStandby, tryApplyStatus,
 unequipAccessory, unequipWeapon, unequipArmor, unequipItemFromMercenary, updateActionButtons, updateCamera,
 updateFogOfWar, updateIncubatorDisplay,
  updateInventoryDisplay, updateMaterialsDisplay, updateMercenaryDisplay,


### PR DESCRIPTION
## Summary
- stop calling `spawnStartingRecipes` when starting a new game
- remove `spawnStartingRecipes` from the exported API

## Testing
- `npm test` *(fails: `healerPurify.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684a787f8d0c8327a2503bc8be771f06