### PR TITLE
Implement skill cooldown tracking

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -29,6 +29,7 @@
             fullness: 0,
             skills: [],
             skillLevels: {},
+            skillCooldowns: {},
             assignedSkills: { '1': null, '2': null },
             equipped: {
                 weapon: null,


### PR DESCRIPTION
## Summary
- add `skillCooldowns` to units and setup turn-based reduction
- prevent skill use when cooldown active for player, mercenaries, and monsters
- set cooldown after each successful skill use

## Testing
- `npm test --silent` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684a8806e8108327b84e3f1dcd800db4