### PR TITLE
Add skill cooldown tests

### DIFF
--- a/tests/mana.test.js
+++ b/tests/mana.test.js
@@ -11,6 +11,7 @@ async function run() {
   win.requestAnimationFrame = fn => fn();
 
   const { gameState, assignSkill, skill1Action, movePlayer, createMonster } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
 
   gameState.player.skills.push('Fireball');
   assignSkill(1, 'Fireball');
@@ -21,12 +22,20 @@ async function run() {
 
   gameState.player.mana = 3;
   skill1Action();
+  if (gameState.player.skillCooldowns['Fireball'] !== SKILL_DEFS['Fireball'].cooldown - 1) {
+    console.error('skill cooldown not set after use');
+    process.exit(1);
+  }
   if (gameState.player.mana !== 0.5) {
     console.error('mana not used or regenerated correctly');
     process.exit(1);
   }
 
   movePlayer(1, 0);
+  if (gameState.player.skillCooldowns['Fireball'] !== 0) {
+    console.error('cooldown not decremented on turn');
+    process.exit(1);
+  }
   if (gameState.player.mana !== 1.0) {
     console.error('mana did not regenerate on turn');
     process.exit(1);

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -54,7 +54,7 @@ async function run() {
 
   // skill scaling
   merc.mana = merc.maxMana = 10;
-  merc.health = getStat(merc, 'maxHealth') - 4;
+  merc.health = Math.floor(getStat(merc, 'maxHealth') * 0.4);
   const healLevel = merc.skillLevels[skillKey];
   const manaBefore = merc.mana;
   const healthBefore = merc.health;

--- a/tests/playerHealPurify.test.js
+++ b/tests/playerHealPurify.test.js
@@ -18,6 +18,7 @@ async function run() {
     tryApplyStatus,
     getStat
   } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
 
   const size = 5;
   gameState.dungeonSize = size;
@@ -43,6 +44,10 @@ async function run() {
     console.error('heal did not heal ally or mana wrong');
     process.exit(1);
   }
+  if (gameState.player.skillCooldowns['Heal'] !== SKILL_DEFS['Heal'].cooldown) {
+    console.error('heal cooldown incorrect');
+    process.exit(1);
+  }
 
   // Purify
   gameState.player.skills.push('Purify');
@@ -56,6 +61,10 @@ async function run() {
   const expectedPurifyMana = 10 - 2 + 0.5;
   if (merc.poison || gameState.player.mana !== expectedPurifyMana) {
     console.error('purify did not remove status or mana wrong');
+    process.exit(1);
+  }
+  if (gameState.player.skillCooldowns['Purify'] !== SKILL_DEFS['Purify'].cooldown) {
+    console.error('purify cooldown incorrect');
     process.exit(1);
   }
 }

--- a/tests/skillCooldown.test.js
+++ b/tests/skillCooldown.test.js
@@ -1,0 +1,68 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { assignSkill, skill1Action, createMonster, processTurn, gameState } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.monsters = [];
+
+  const monster = createMonster('ZOMBIE', 2, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  gameState.player.skills.push('Fireball');
+  assignSkill(1, 'Fireball');
+
+  gameState.player.mana = 10;
+  skill1Action();
+  if (gameState.player.skillCooldowns['Fireball'] !== SKILL_DEFS['Fireball'].cooldown - 1) {
+    console.error('cooldown not set correctly');
+    process.exit(1);
+  }
+
+  processTurn();
+  if (gameState.player.skillCooldowns['Fireball'] !== 0) {
+    console.error('cooldown not decremented by processTurn');
+    process.exit(1);
+  }
+
+  const beforeProj = gameState.projectiles.length;
+  skill1Action();
+  if (gameState.player.skillCooldowns['Fireball'] !== SKILL_DEFS['Fireball'].cooldown - 1) {
+    console.error('cooldown not reset on reuse');
+    process.exit(1);
+  }
+  if (gameState.projectiles.length !== beforeProj + 1) {
+    console.error('skill should fire when off cooldown');
+    process.exit(1);
+  }
+
+  const beforeProj2 = gameState.projectiles.length;
+  const beforeMana2 = gameState.player.mana;
+  skill1Action();
+  if (gameState.projectiles.length !== beforeProj2 || beforeMana2 !== gameState.player.mana) {
+    console.error('skill should not activate while on cooldown');
+    process.exit(1);
+  }
+  if (gameState.player.skillCooldowns['Fireball'] !== 0) {
+    console.error('cooldown not decremented after blocked use');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add new `skillCooldown.test.js` to ensure cooldown mechanics
- verify cooldown use and decrement in mana and purify tests
- update mercenary skill upgrade test setup for cooldown logic

## Testing
- `npm test` *(fails: purify did not remove status or mana cost incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684aa1c977b08327aee729a1a06bbee2