### PR TITLE
Fix shield stacking logic

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1734,12 +1734,20 @@ const MERCENARY_NAMES = [
             const power = getStat(caster, 'magicPower');
             const amount = Math.floor(power * level);
             if (amount <= 0) return false;
-            target.shield = (target.shield || 0) + amount;
-            target.shieldTurns = skillInfo.duration || 5;
-            const name = target === gameState.player ? '플레이어' : target.name;
-            const img = caster === gameState.player ? getPlayerImage() : getMercImage(caster.type);
-            addMessage(`${skillInfo.icon} ${caster.name}의 ${skillInfo.name}이(가) ${name}에게 ${formatNumber(amount)} 보호막을 부여했습니다.`, 'mercenary', null, img);
-            return true;
+
+            let applied = false;
+            if (!target.shield || amount > target.shield) {
+                target.shield = amount;
+                target.shieldTurns = skillInfo.duration || 5;
+                applied = true;
+            }
+
+            if (applied) {
+                const name = target === gameState.player ? '플레이어' : target.name;
+                const img = caster === gameState.player ? getPlayerImage() : getMercImage(caster.type);
+                addMessage(`${skillInfo.icon} ${caster.name}의 ${skillInfo.name}이(가) ${name}에게 ${formatNumber(amount)} 보호막을 부여했습니다.`, 'mercenary', null, img);
+            }
+            return applied;
         }
 
         // 피해를 적용할 때 보호막을 우선 소모합니다.

--- a/tests/shieldPriority.test.js
+++ b/tests/shieldPriority.test.js
@@ -1,0 +1,50 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, createMercenary, assignSkill, skill1Action, movePlayer, getStat } = win;
+
+  gameState.player.skills.push('GuardianHymn');
+  assignSkill(1, 'GuardianHymn');
+
+  const merc = createMercenary('WARRIOR', gameState.player.x + 1, gameState.player.y);
+  gameState.activeMercenaries.push(merc);
+
+  // First cast with base intelligence
+  gameState.player.intelligence = 5;
+  gameState.player.mana = 10;
+  skill1Action();
+  const firstShield = gameState.player.shield;
+
+  // Wait for cooldown and cast again with same power
+  gameState.player.mana = 10;
+  movePlayer(1, 0);
+  movePlayer(-1, 0);
+  skill1Action();
+  if (gameState.player.shield !== firstShield) {
+    console.error('shield stacked when it should not');
+    process.exit(1);
+  }
+
+  // Increase power and cast again; shield should update to new higher value
+  gameState.player.intelligence = 10;
+  gameState.player.mana = 10;
+  movePlayer(1, 0);
+  movePlayer(-1, 0);
+  skill1Action();
+  const expected = Math.floor(getStat(gameState.player, 'magicPower'));
+  if (gameState.player.shield !== expected) {
+    console.error('higher shield value not applied');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- prevent shield stacking and only keep higher value
- add test to ensure shield replacement prioritizes larger shields

## Testing
- `npm test` *(fails: purify did not remove status or mana cost incorrect)*
- `node tests/shieldPriority.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684ab803a754832781e6405e3ce2c494