### PR TITLE
Add cooldown info to skill damage alert

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2144,8 +2144,8 @@ const MERCENARY_NAMES = [
         function showSkillDamage(owner, key, defs) {
             if (!key) return;
             const dmg = estimateSkillDamage(owner, key, defs);
-            const name = defs[key].name;
-            alert(`${name} 예상 피해: ${formatNumber(dmg)}`);
+            const { name, cooldown: cd } = defs[key];
+            alert(`${name} 예상 피해: ${formatNumber(dmg)} (쿨타임 ${cd})`);
         }
 
         function showAuraDetails(key, lvl) {


### PR DESCRIPTION
## Summary
- include the skill's cooldown in `showSkillDamage`

## Testing
- `npm test` *(fails: `healerPurify.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684abd2092ac832796392b4afa768d59