### PR TITLE
ApplyShield side check

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1731,6 +1731,7 @@ const MERCENARY_NAMES = [
         }
 
         function applyShield(caster, target, skillInfo, level = 1) {
+            if (!isSameSide(caster, target)) return false;
             const power = getStat(caster, 'magicPower');
             const amount = Math.floor(power * level);
             if (amount <= 0) return false;

--- a/tests/guardianHymn.test.js
+++ b/tests/guardianHymn.test.js
@@ -10,7 +10,7 @@ async function run() {
   win.updateSkillDisplay = () => {};
   win.requestAnimationFrame = fn => fn();
 
-  const { gameState, createMercenary, assignSkill, skill1Action, getStat } = win;
+  const { gameState, createMercenary, createMonster, assignSkill, skill1Action, applyShield, getStat } = win;
   const SKILL_DEFS = win.eval('SKILL_DEFS');
 
   gameState.player.skills.push('GuardianHymn');
@@ -18,6 +18,10 @@ async function run() {
 
   const merc = createMercenary('WARRIOR', gameState.player.x + 1, gameState.player.y);
   gameState.activeMercenaries.push(merc);
+
+  // create enemy adjacent
+  const monster = createMonster('GOBLIN', gameState.player.x - 1, gameState.player.y, 1);
+  gameState.monsters.push(monster);
 
   gameState.player.intelligence = 5;
   gameState.player.mana = 10;
@@ -30,6 +34,12 @@ async function run() {
   }
   if (gameState.player.shieldTurns !== SKILL_DEFS['GuardianHymn'].duration - 1) {
     console.error('duration incorrect');
+    process.exit(1);
+  }
+
+  // enemy should not receive shield if targeted directly
+  if (applyShield(gameState.player, monster, SKILL_DEFS['GuardianHymn'])) {
+    console.error('enemy received shield');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- block shielding units on the opposing side
- test Guardian Hymn cannot shield enemies

## Testing
- `npm test` *(fails: healerPurify.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684abd21af2c8327ac1e8cf5879b92a1