### PR TITLE
Parametrize nova animation with CELL_SIZE

### DIFF
--- a/index.html
+++ b/index.html
@@ -800,6 +800,8 @@
             pointer-events: none;
             z-index: 1000;
             animation: nova-expand 0.8s ease-out forwards;
+            width: var(--start-size);
+            height: var(--start-size);
         }
         .fire-nova {
             background: radial-gradient(circle, rgba(255,69,0,0.8) 0%, rgba(255,140,0,0.4) 50%, transparent 100%);
@@ -811,13 +813,13 @@
         }
         @keyframes nova-expand {
             0% {
-                width: 33px;
-                height: 33px;
+                width: var(--start-size);
+                height: var(--start-size);
                 opacity: 1;
             }
             100% {
-                width: 231px;
-                height: 231px;
+                width: var(--end-size);
+                height: var(--end-size);
                 opacity: 0;
             }
         }

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4512,7 +4512,7 @@ function killMonster(monster) {
             const container = document.querySelector('.dungeon-container');
             if (!dungeonElement || !container) return;
 
-            const cellSize = 33; // 32px + 1px gap
+            const cellSize = CELL_SIZE; // 32px + 1px gap
 
             // 현재 컨테이너 크기에 맞춰 보이는 셀 수 계산
             const visibleX = Math.floor(container.clientWidth / cellSize);
@@ -4915,14 +4915,16 @@ function killMonster(monster) {
             const dungeonEl = document.getElementById('dungeon');
             if (!dungeonEl) return;
 
-            const cellSize = 33;
+            const cellSize = CELL_SIZE;
             const centerX = (x - gameState.camera.x) * cellSize + cellSize / 2;
             const centerY = (y - gameState.camera.y) * cellSize + cellSize / 2;
 
             const novaDiv = document.createElement('div');
             novaDiv.className = `nova-effect ${type}-nova`;
-            novaDiv.style.left = `${centerX - 16.5}px`;
-            novaDiv.style.top = `${centerY - 16.5}px`;
+            novaDiv.style.setProperty('--start-size', `${cellSize}px`);
+            novaDiv.style.setProperty('--end-size', `${cellSize * (radius * 2 + 1)}px`);
+            novaDiv.style.left = `${centerX - cellSize / 2}px`;
+            novaDiv.style.top = `${centerY - cellSize / 2}px`;
             dungeonEl.appendChild(novaDiv);
 
             createNovaParticles(centerX, centerY, type, radius);
@@ -4940,7 +4942,7 @@ function killMonster(monster) {
 
             for (let i = 0; i < particleCount; i++) {
                 const angle = (i / particleCount) * Math.PI * 2;
-                const distance = (radius * 16.5) + (Math.random() * 33);
+                const distance = (radius * (CELL_SIZE / 2)) + (Math.random() * CELL_SIZE);
                 const particleX = centerX + Math.cos(angle) * distance;
                 const particleY = centerY + Math.sin(angle) * distance;
 

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,7 @@
 ((global) => {
     const MONSTER_VISION = 7; // 몬스터가 플레이어를 인지하는 최대 거리
     const FOG_RADIUS = 5;     // 플레이어 주변의 시야 반경
+    const CELL_SIZE = 33;     // 한 셀의 크기(px)
 
     let gameState = {
         turn: 0,
@@ -81,7 +82,8 @@
     global.gameState = gameState;
     global.MONSTER_VISION = MONSTER_VISION;
     global.FOG_RADIUS = FOG_RADIUS;
+    global.CELL_SIZE = CELL_SIZE;
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS };
+        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE };
     }
 })(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- define global `CELL_SIZE` constant
- use the constant in camera logic and nova visual effects
- drive nova keyframe sizes using CSS variables so the effect scales with `CELL_SIZE`

## Testing
- `npm test` *(fails: healerPurify.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ac8e838f48327bf66eabe6ccb21c6