### PR TITLE
Add CELL_WIDTH constant and CSS variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,19 +47,22 @@
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.8);
             border: 2px solid #444;
         }
+        :root {
+            --cell-width: 32px;
+        }
         .dungeon {
             position: absolute;
             display: grid;
             --dungeon-size: 80;
-            grid-template-columns: repeat(var(--dungeon-size), 32px);
-            grid-template-rows: repeat(var(--dungeon-size), 32px);
+            grid-template-columns: repeat(var(--dungeon-size), var(--cell-width));
+            grid-template-rows: repeat(var(--dungeon-size), var(--cell-width));
             gap: 1px;
             transition: transform 0.15s ease;
             will-change: transform;
         }
         .cell {
-            width: 32px;
-            height: 32px;
+            width: var(--cell-width);
+            height: var(--cell-width);
             display: flex;
             justify-content: center;
             align-items: center;

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4101,8 +4101,8 @@ function killMonster(monster) {
             const dungeonEl = document.getElementById('dungeon');
             if (dungeonEl) {
                 dungeonEl.style.setProperty('--dungeon-size', size);
-                dungeonEl.style.gridTemplateColumns = `repeat(${size}, 32px)`;
-                dungeonEl.style.gridTemplateRows = `repeat(${size}, 32px)`;
+                dungeonEl.style.gridTemplateColumns = `repeat(${size}, ${CELL_WIDTH}px)`;
+                dungeonEl.style.gridTemplateRows = `repeat(${size}, ${CELL_WIDTH}px)`;
             }
             gameState.dungeon = [];
             gameState.fogOfWar = [];
@@ -4489,8 +4489,8 @@ function killMonster(monster) {
             gameState.cellElements = [];
 
             dungeonEl.style.setProperty('--dungeon-size', size);
-            dungeonEl.style.gridTemplateColumns = `repeat(${size}, 32px)`;
-            dungeonEl.style.gridTemplateRows = `repeat(${size}, 32px)`;
+            dungeonEl.style.gridTemplateColumns = `repeat(${size}, ${CELL_WIDTH}px)`;
+            dungeonEl.style.gridTemplateRows = `repeat(${size}, ${CELL_WIDTH}px)`;
 
             for (let y = 0; y < size; y++) {
                 const cellRow = [];

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,8 @@
 ((global) => {
     const MONSTER_VISION = 7; // 몬스터가 플레이어를 인지하는 최대 거리
     const FOG_RADIUS = 5;     // 플레이어 주변의 시야 반경
+    const CELL_SIZE = 33;     // 셀 크기(갭 포함)
+    const CELL_WIDTH = CELL_SIZE - 1; // 실제 셀 너비
 
     let gameState = {
         turn: 0,
@@ -81,7 +83,12 @@
     global.gameState = gameState;
     global.MONSTER_VISION = MONSTER_VISION;
     global.FOG_RADIUS = FOG_RADIUS;
+    global.CELL_SIZE = CELL_SIZE;
+    global.CELL_WIDTH = CELL_WIDTH;
+    if (typeof document !== 'undefined') {
+        document.documentElement.style.setProperty('--cell-width', `${CELL_WIDTH}px`);
+    }
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS };
+        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH };
     }
 })(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/style.css
+++ b/style.css
@@ -243,8 +243,8 @@
 }
 
 .tile-tab-slot {
-  width: 32px;
-  height: 32px;
+  width: var(--cell-width);
+  height: var(--cell-width);
   background-color: #222;
   border: 1px solid #666;
   border-radius: 4px;
@@ -415,8 +415,8 @@
   }
   @keyframes nova-expand {
       0% {
-          width: 33px;
-          height: 33px;
+          width: calc(var(--cell-width) + 1px);
+          height: calc(var(--cell-width) + 1px);
           opacity: 1;
       }
       100% {


### PR DESCRIPTION
## Summary
- expose `CELL_WIDTH` derived from `CELL_SIZE`
- use `--cell-width` variable for dungeon grid and cells
- reference `CELL_WIDTH` when updating grid templates
- sync related CSS

## Testing
- `npm test` *(fails: purify did not remove status or mana cost incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684ace6a170083279384bdc44d42b23c