### PR TITLE
Adjust mercenary self-heal threshold

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -6715,7 +6715,7 @@ function processTurn() {
                     }
                 }
 
-                if (!healOnCooldown && mercenary.health < getStat(mercenary, 'maxHealth') * 0.5 && mercenary.mana >= manaCost) {
+                if (!healOnCooldown && mercenary.health < getStat(mercenary, 'maxHealth') && mercenary.mana >= manaCost) {
                     const healed = knowsHeal
                         ? healTarget(mercenary, mercenary, skillInfo, healLevel)
                         : healTarget(mercenary, mercenary);


### PR DESCRIPTION
## Summary
- let healers heal themselves whenever missing HP

## Testing
- `npm test` *(fails: `mercenaryFollow.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684b11594d248327aa4ede47749987a3