### PR TITLE
Add local server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This project is a lightweight browser-based dungeon crawler. It lets players exp
 
 Open `index.html` in a modern web browser to start the game. The player now begins with every available skill already learned, so no class selection is required.
 
+```bash
+npx http-server
+```
+
+Running a small HTTP server from the project directory is recommended because some browsers block
+ES module loading when opening the file directly via `file://`. You can still open `index.html`
+without a server, but you may need to adjust browser settings to permit local module imports.
+
 ### Dungeon Generation
 Each floor is carved from a depth-first search maze. Corridors span seven tiles,
 and the exit is placed on a randomly chosen cell that the algorithm visited.


### PR DESCRIPTION
## Summary
- document launching via `npx http-server`
- warn about module loading restrictions when using the `file://` protocol

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ba338495c8327b15754800908de04