### PR TITLE
Fix monster exp test

### DIFF
--- a/tests/monsterExp.test.js
+++ b/tests/monsterExp.test.js
@@ -30,10 +30,13 @@ async function run() {
   gameState.monsters = [monster];
   gameState.dungeon[monster.y][monster.x] = 'monster';
 
+  const origRoll = win.rollDice;
+  win.rollDice = notation => notation.includes('d20') ? 20 : 4;
   const origRandom = win.Math.random;
   win.Math.random = () => 0.99; // ensure hit
   monsterAttack(monster);
   win.Math.random = origRandom;
+  win.rollDice = origRoll;
 
   if (monster.level < 2) {
     console.error('monster did not gain experience from kill');


### PR DESCRIPTION
## Summary
- stabilize monsterExp.test.js by stubbing rollDice

## Testing
- `node tests/monsterExp.test.js`
- `npm test --silent` *(fails at mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ba336dca08327945462702187f476