### PR TITLE
Improve unique skill log readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,6 +564,10 @@
             background-color: #5f4b00;
             border-left-color: #FFD700;
         }
+        .message.unique-skill {
+            background-color: #2a2a2a;
+            border-left-color: #FFD700;
+        }
         .message.item {
             background-color: #3d3051;
             border-left-color: #9575CD;

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2019,7 +2019,8 @@ const MERCENARY_NAMES = [
                             const unitName = unit.name || '유닛';
                             const itemName = item.name || '장비';
                             const skillName = skill ? skill.name : proc.skill;
-                            addMessage(`✨ ${unitName}의 ${itemName} 효과로 ${skillName} 스킬이 발동했습니다!`, 'treasure', null, getUnitImage(unit));
+                            const msgType = item.tier === 'unique' ? 'unique-skill' : 'treasure';
+                            addMessage(`✨ ${unitName}의 ${itemName} 효과로 ${skillName} 스킬이 발동했습니다!`, msgType, null, getUnitImage(unit));
                             if (typeof triggerProcSkill === 'function') {
                                 triggerProcSkill(unit, opponent, proc);
                             }


### PR DESCRIPTION
## Summary
- style unique equipment skill activations with a new `.message.unique-skill` class
- use the new message type in `handleProcs`

## Testing
- `npm test` *(fails: mana.test.js, teleport.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ba66f7b6483278f5ab48faf89ea22