### PR TITLE
Fix accessory equip info display

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -8024,7 +8024,7 @@ function processTurn() {
                 }
                 choices.push({ label: fullLabel, action });
                 const btn = document.createElement('button');
-                btn.textContent = fullLabel;
+                btn.innerHTML = fullLabel;
                 btn.className = 'target-button';
                 btn.onclick = () => { action(); hideItemTargetPanel(); };
                 content.appendChild(btn);


### PR DESCRIPTION
## Summary
- fix markup rendering for equipped accessories when choosing a target

## Testing
- `npm test` *(fails: mercenaryFollow.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ba694986c8327a07ecd3b51a44858