### PR TITLE
Fix hymn skill logic and add test

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1486,7 +1486,7 @@ const MERCENARY_NAMES = [
             IceNova: { name: 'Ice Nova', icon: '❄️', damageDice: '1d6', radius: 3, magic: true, element: 'ice', manaCost: 4, cooldown: 3 },
             Heal: { name: 'Heal', icon: '💖', heal: 10, range: 2, manaCost: 3, cooldown: 0 },
             Purify: { name: 'Purify', icon: '🌀', purify: true, range: 2, manaCost: 2, cooldown: 0 },
-            Teleport: { name: 'Teleport', icon: '🌀', teleport: true, manaCost: 2, cooldown: 5 },
+            Teleport: { name: 'Teleport', icon: '🌀', teleport: true, manaCost: 2, cooldown: 1 },
             GuardianHymn: { name: '수호의 찬가', icon: '🎶', range: 3, manaCost: 3, shield: true, duration: 5, cooldown: 3 },
             CourageHymn: { name: '용기의 찬가', icon: '🎵', range: 3, manaCost: 3, attackBuff: true, duration: 5, cooldown: 3 },
             DoubleStrike: { name: 'Double Strike', icon: '🔪', range: 1, manaCost: 3, melee: true, hits: 2, cooldown: 2 },
@@ -6917,29 +6917,47 @@ function processTurn() {
                 } else if (skillKey === 'GuardianHymn') {
                     let nearestAlly = null;
                     let distAlly = Infinity;
-                    const allies = [gameState.player, ...gameState.activeMercenaries.filter(m=>m.alive && m!==mercenary)];
-                    allies.forEach(a=>{ const d=getDistance(mercenary.x, mercenary.y, a.x, a.y); if(d<=skillInfo.range && d<distAlly){distAlly=d; nearestAlly=a;} });
-                    mercenary.mana -= skillManaCost;
-                    SoundEngine.playSound('auraActivateMinor');
-                    applyShield(mercenary, mercenary, skillInfo, skillLevel);
-                    if(nearestAlly) applyShield(mercenary, nearestAlly, skillInfo, skillLevel);
-                    updateMercenaryDisplay();
-                    mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
-                    mercenary.hasActed = true;
-                    return;
+                    const allies = [gameState.player, ...gameState.activeMercenaries.filter(m => m.alive && m !== mercenary)];
+                    allies.forEach(a => {
+                        const d = getDistance(mercenary.x, mercenary.y, a.x, a.y);
+                        if (d <= skillInfo.range && d < distAlly) {
+                            distAlly = d;
+                            nearestAlly = a;
+                        }
+                    });
+
+                    const appliedSelf = applyShield(mercenary, mercenary, skillInfo, skillLevel);
+                    const appliedAlly = nearestAlly ? applyShield(mercenary, nearestAlly, skillInfo, skillLevel) : false;
+                    if (appliedSelf || appliedAlly) {
+                        mercenary.mana -= skillManaCost;
+                        SoundEngine.playSound('auraActivateMinor');
+                        updateMercenaryDisplay();
+                        mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
+                        mercenary.hasActed = true;
+                        return;
+                    }
                 } else if (skillKey === 'CourageHymn') {
                     let nearestAlly = null;
                     let distAlly = Infinity;
-                    const allies = [gameState.player, ...gameState.activeMercenaries.filter(m=>m.alive && m!==mercenary)];
-                    allies.forEach(a=>{ const d=getDistance(mercenary.x, mercenary.y, a.x, a.y); if(d<=skillInfo.range && d<distAlly){distAlly=d; nearestAlly=a;} });
-                    mercenary.mana -= skillManaCost;
-                    SoundEngine.playSound('auraActivateMajor');
-                    applyAttackBuff(mercenary, mercenary, skillInfo, skillLevel);
-                    if(nearestAlly) applyAttackBuff(mercenary, nearestAlly, skillInfo, skillLevel);
-                    updateMercenaryDisplay();
-                    mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
-                    mercenary.hasActed = true;
-                    return;
+                    const allies = [gameState.player, ...gameState.activeMercenaries.filter(m => m.alive && m !== mercenary)];
+                    allies.forEach(a => {
+                        const d = getDistance(mercenary.x, mercenary.y, a.x, a.y);
+                        if (d <= skillInfo.range && d < distAlly) {
+                            distAlly = d;
+                            nearestAlly = a;
+                        }
+                    });
+
+                    const appliedSelf = applyAttackBuff(mercenary, mercenary, skillInfo, skillLevel);
+                    const appliedAlly = nearestAlly ? applyAttackBuff(mercenary, nearestAlly, skillInfo, skillLevel) : false;
+                    if (appliedSelf || appliedAlly) {
+                        mercenary.mana -= skillManaCost;
+                        SoundEngine.playSound('auraActivateMajor');
+                        updateMercenaryDisplay();
+                        mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
+                        mercenary.hasActed = true;
+                        return;
+                    }
                 } else if (skillKey === 'ChargeAttack' && nearestMonster && nearestDistance <= skillInfo.dashRange && hasLineOfSight(mercenary.x, mercenary.y, nearestMonster.x, nearestMonster.y)) {
                     let attackValue = getStat(mercenary, 'attack');
                     attackValue = Math.floor(attackValue * skillInfo.multiplier * skillLevel);

--- a/tests/multiHealerHymn.test.js
+++ b/tests/multiHealerHymn.test.js
@@ -1,0 +1,74 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    hireMercenary,
+    processMercenaryTurn,
+    gameState,
+    getStat
+  } = win;
+  const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
+
+  const size = 5;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.player.x = 2;
+  gameState.player.y = 2;
+  gameState.dungeon[2][2] = 'empty';
+  gameState.player.gold = 1000;
+
+  hireMercenary('HEALER');
+  hireMercenary('HEALER');
+  const healer1 = gameState.activeMercenaries[0];
+  const healer2 = gameState.activeMercenaries[1];
+
+  healer1.skill = 'GuardianHymn';
+  healer2.skill = 'GuardianHymn';
+  healer1.mana = healer1.maxMana = 10;
+  healer2.mana = healer2.maxMana = 10;
+
+  const shieldVal1 = Math.floor(getStat(healer1, 'magicPower'));
+  const shieldVal2 = Math.floor(getStat(healer2, 'magicPower'));
+
+  healer1.shield = shieldVal1;
+  healer1.shieldTurns = MERCENARY_SKILLS['GuardianHymn'].duration;
+  healer2.shield = shieldVal2;
+  healer2.shieldTurns = MERCENARY_SKILLS['GuardianHymn'].duration;
+  const playerShield = Math.floor(getStat(healer1, 'magicPower'));
+  gameState.player.shield = playerShield;
+  gameState.player.shieldTurns = MERCENARY_SKILLS['GuardianHymn'].duration;
+
+  const mana1 = healer1.mana;
+  const mana2 = healer2.mana;
+  const cd1 = healer1.skillCooldowns['GuardianHymn'] || 0;
+  const cd2 = healer2.skillCooldowns['GuardianHymn'] || 0;
+
+  const origRandom = win.Math.random;
+  win.Math.random = () => 0;
+  processMercenaryTurn(healer1, gameState.monsters);
+  processMercenaryTurn(healer2, gameState.monsters);
+  win.Math.random = origRandom;
+
+  if (healer1.mana !== mana1 || healer2.mana !== mana2) {
+    console.error('mana consumed despite full shields');
+    process.exit(1);
+  }
+  if ((healer1.skillCooldowns['GuardianHymn'] || 0) !== cd1 ||
+      (healer2.skillCooldowns['GuardianHymn'] || 0) !== cd2) {
+    console.error('cooldown applied despite full shields');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- improve GuardianHymn and CourageHymn AI to only spend resources when buffs are applied
- lower Teleport cooldown so consecutive casts work
- add multi healer hymn regression test

## Testing
- `node runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684ba5df3838832793f17ce2bdc1acf1