### PR TITLE
Fix nova effect positioning

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5230,9 +5230,8 @@ function killMonster(monster) {
             const dungeonEl = document.getElementById('dungeon');
             if (!dungeonEl) return;
 
-            const cellSize = 33;
-            const centerX = (x - gameState.camera.x) * cellSize + cellSize / 2;
-            const centerY = (y - gameState.camera.y) * cellSize + cellSize / 2;
+            const centerX = x * CELL_SIZE + CELL_SIZE / 2;
+            const centerY = y * CELL_SIZE + CELL_SIZE / 2;
 
             const novaDiv = document.createElement('div');
             novaDiv.className = `nova-effect ${type}-nova`;
@@ -5411,9 +5410,8 @@ function killMonster(monster) {
             const dungeonEl = document.getElementById('dungeon');
             if (!dungeonEl) return;
 
-            const cellSize = 33;
-            const centerX = (unit.x - gameState.camera.x) * cellSize + cellSize / 2;
-            const centerY = (unit.y - gameState.camera.y) * cellSize + cellSize / 2;
+            const centerX = unit.x * CELL_SIZE + CELL_SIZE / 2;
+            const centerY = unit.y * CELL_SIZE + CELL_SIZE / 2;
 
             const overlay = document.createElement('div');
             overlay.className = 'skill-effect-overlay';


### PR DESCRIPTION
## Summary
- center nova effect calculations on world coordinates
- adjust skill overlay positioning to ignore camera offset

## Testing
- `npm test` *(fails: teleport.test.js failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ba5cb1e708327a28a47c1ffda3957