### PR TITLE
Fix nova proc damage calculation

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2060,8 +2060,14 @@ const MERCENARY_NAMES = [
                 });
 
                 aoeTargets.forEach(enemy => {
-                    const attackValue = rollDice(skill.damageDice) * level + getStat(source, 'magicPower');
-                    const result = performAttack(source, enemy, { attackValue, magic: true, element: skill.element, skipProcs: true });
+                    const attackValue = getStat(source, 'magicPower');
+                    const result = performAttack(source, enemy, {
+                        attackValue,
+                        magic: true,
+                        element: skill.element,
+                        damageDice: skill.damageDice,
+                        skipProcs: true
+                    });
                     if (result.hit) {
                          addMessage(`${skill.icon} ${enemy.name}에게 ${formatNumber(result.damage)}의 광역 피해!`, 'combat', null, getUnitImage(source));
                          if(enemy.health <= 0) {
@@ -2075,11 +2081,12 @@ const MERCENARY_NAMES = [
             else if (skill.damageDice && skill.range) {
                 if (!target) return;
 
-                const attackValue = rollDice(skill.damageDice) * level + getStat(source, 'magicPower');
+                const attackValue = getStat(source, 'magicPower');
                 const result = performAttack(source, target, {
-                    attackValue: attackValue,
+                    attackValue,
                     magic: skill.magic,
                     element: skill.element,
+                    damageDice: skill.damageDice,
                     skipProcs: true
                 });
 

--- a/tests/uniqueNovaProc.test.js
+++ b/tests/uniqueNovaProc.test.js
@@ -1,0 +1,54 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, createMonster, createItem, performAttack } = win;
+
+  const size = 7;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.player.x = 3;
+  gameState.player.y = 3;
+  gameState.dungeon[3][3] = 'empty';
+
+  const inRange = createMonster('ZOMBIE', 4, 3);
+  const outRange = createMonster('ZOMBIE', 7, 3);
+  gameState.monsters.push(inRange, outRange);
+  gameState.dungeon[inRange.y][inRange.x] = 'monster';
+  gameState.dungeon[outRange.y][outRange.x] = 'monster';
+
+  const weapon = createItem('shortSword', 0, 0);
+  weapon.tier = 'unique';
+  weapon.procs = [{ trigger: 'onAttack', skill: 'FireNova', chance: 1 }];
+  gameState.player.equipped.weapon = weapon;
+
+  win.rollDice = spec => {
+    if (spec === '1d20') return 20;
+    const m = /^1d(\d+)/.exec(spec);
+    if (m) return parseInt(m[1]);
+    return 1;
+  };
+  win.Math.random = () => 0;
+
+  performAttack(gameState.player, inRange);
+
+  if (inRange.health === inRange.maxHealth) {
+    console.error('in-range enemy not damaged');
+    process.exit(1);
+  }
+  if (outRange.health !== outRange.maxHealth) {
+    console.error('out-of-range enemy damaged');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- fix double-rolling of proc AoE damage
- send skill damage dice to `performAttack`
- add unit test for unique-item Nova procs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb015e3c0832797f59d0a2ff74e32