### PR TITLE
Fix supportive proc targeting

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2023,7 +2023,8 @@ const MERCENARY_NAMES = [
                             const msgType = item.tier === 'unique' ? 'unique-skill' : 'treasure';
                             addMessage(`✨ ${unitName}의 ${itemName} 효과로 ${skillName} 스킬이 발동했습니다!`, msgType, null, getUnitImage(unit));
                             if (typeof triggerProcSkill === 'function') {
-                                triggerProcSkill(unit, opponent, proc);
+                                const supportive = skill && (skill.heal || skill.shield || skill.attackBuff || skill.buff);
+                                triggerProcSkill(unit, supportive ? null : opponent, proc);
                             }
                         }
                     }

--- a/tests/courageAmulet.test.js
+++ b/tests/courageAmulet.test.js
@@ -1,0 +1,41 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, createMonster, createItem, performAttack, getStat } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  const monster = createMonster('GOBLIN', gameState.player.x + 1, gameState.player.y, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  const amulet = createItem('courageAmulet', 0, 0);
+  gameState.player.equipped.accessory1 = amulet;
+  gameState.player.intelligence = 5;
+
+  win.Math.random = () => 0;
+  win.rollDice = spec => {
+    if (spec === '1d20') return 20;
+    const m = /^1d(\d+)/.exec(spec);
+    if (m) return parseInt(m[1]);
+    return 1;
+  };
+
+  performAttack(monster, gameState.player);
+
+  const expected = Math.floor(getStat(gameState.player, 'magicPower') * (amulet.procs[0].level || 1));
+  if (gameState.player.attackBuff !== expected || gameState.player.attackBuffTurns !== SKILL_DEFS['CourageHymn'].duration) {
+    console.error('courage amulet did not apply buff');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/guardianAmulet.test.js
+++ b/tests/guardianAmulet.test.js
@@ -1,0 +1,41 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, createMonster, createItem, performAttack, getStat } = win;
+  const SKILL_DEFS = win.eval('SKILL_DEFS');
+
+  const monster = createMonster('GOBLIN', gameState.player.x + 1, gameState.player.y, 1);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  const amulet = createItem('guardianAmulet', 0, 0);
+  gameState.player.equipped.accessory1 = amulet;
+  gameState.player.intelligence = 5;
+
+  win.Math.random = () => 0;
+  win.rollDice = spec => {
+    if (spec === '1d20') return 20;
+    const m = /^1d(\d+)/.exec(spec);
+    if (m) return parseInt(m[1]);
+    return 1;
+  };
+
+  performAttack(monster, gameState.player);
+
+  const expected = Math.floor(getStat(gameState.player, 'magicPower') * (amulet.procs[0].level || 1));
+  if (gameState.player.shield !== expected || gameState.player.shieldTurns !== SKILL_DEFS['GuardianHymn'].duration) {
+    console.error('guardian amulet did not apply shield');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- ensure procs for supportive skills buff the source
- test Guardian Amulet proc
- test Courage Amulet proc

## Testing
- `node tests/guardianAmulet.test.js`
- `node tests/courageAmulet.test.js`
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684bb351463c8327b6e4673c73fde87c