### PR TITLE
Add life steal affix

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1695,6 +1695,7 @@ const MERCENARY_NAMES = [
             { name: 'Sturdy', modifiers: { defense: 1 } },
             { name: 'Refreshing', modifiers: { healthRegen: 1 } },
             { name: 'Mystic', modifiers: { manaRegen: 1 } },
+            { name: 'Vampiric', modifiers: { lifeSteal: 0.05 } },
             { name: 'Venomous', modifiers: { status: 'poison' } },
             { name: 'Serrated', modifiers: { status: 'bleed' } },
             { name: 'Smoldering', modifiers: { status: 'burn' } },
@@ -1714,6 +1715,7 @@ const MERCENARY_NAMES = [
             { name: 'of Bleeding', modifiers: { status: 'bleed' } },
             { name: 'of Burning', modifiers: { status: 'burn' } },
             { name: 'of Frost', modifiers: { status: 'freeze' } },
+            { name: 'of Leeching', modifiers: { lifeSteal: 0.05 } },
             { name: 'of Poison Resistance', modifiers: { poisonResist: 0.3 } },
             { name: 'of Bleed Resistance', modifiers: { bleedResist: 0.3 } },
             { name: 'of Burn Resistance', modifiers: { burnResist: 0.3 } },
@@ -2203,6 +2205,17 @@ const MERCENARY_NAMES = [
             applyDamage(defender, damage);
             if (!crit) SoundEngine.playSound('takeDamage');
 
+            const lifeSteal = getStat(attacker, 'lifeSteal');
+            if (lifeSteal) {
+                const heal = Math.floor(damage * lifeSteal);
+                if (heal > 0) {
+                    attacker.health = Math.min(getStat(attacker, 'maxHealth'), attacker.health + heal);
+                    refreshDetailPanel(attacker);
+                    const name = attacker === gameState.player ? '플레이어' : attacker.name;
+                    addMessage(`🩸 ${name}이(가) ${formatNumber(heal)} 만큼 흡혈했습니다.`, 'combat');
+                }
+            }
+
             let statusApplied = false;
             const statusEffects = [];
             if (status) {
@@ -2309,6 +2322,7 @@ const MERCENARY_NAMES = [
             if (item.bleedResist !== undefined) stats.push(`출혈저항+${formatNumber(item.bleedResist * 100)}%`);
             if (item.burnResist !== undefined) stats.push(`화상저항+${formatNumber(item.burnResist * 100)}%`);
             if (item.freezeResist !== undefined) stats.push(`동결저항+${formatNumber(item.freezeResist * 100)}%`);
+            if (item.lifeSteal !== undefined) stats.push(`흡혈+${formatNumber(item.lifeSteal * 100)}%`);
             if (item.status) stats.push(`${item.status} 부여`);
             const levelText = item.enhanceLevel ? ` +Lv.${item.enhanceLevel}` : '';
             const name = formatItemName(item);

--- a/tests/lifeStealAffix.test.js
+++ b/tests/lifeStealAffix.test.js
@@ -1,0 +1,60 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createItem, formatItem, gameState, createMonster, performAttack, getStat } = win;
+
+  const seq = [0, 0, 0.55, 0, 0.65];
+  const origRandom = win.Math.random;
+  win.Math.random = () => seq.shift() ?? origRandom();
+
+  const weapon = createItem('shortSword', 0, 0);
+
+  win.Math.random = origRandom;
+
+  if (weapon.prefix !== 'Vampiric' || weapon.suffix !== 'of Leeching') {
+    console.error('affixes not applied');
+    process.exit(1);
+  }
+  if (Math.abs(weapon.lifeSteal - 0.1) > 1e-6) {
+    console.error('lifesteal value incorrect');
+    process.exit(1);
+  }
+  const desc = formatItem(weapon);
+  if (!desc.includes('흡혈+')) {
+    console.error('formatItem missing lifesteal info');
+    process.exit(1);
+  }
+
+  gameState.player.equipped.weapon = weapon;
+  const monster = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  gameState.player.health = 10;
+
+  win.rollDice = spec => {
+    if (spec === '1d20') return 20;
+    const m = /^1d(\d+)/.exec(spec);
+    if (m) return parseInt(m[1], 10);
+    return 1;
+  };
+  win.Math.random = () => 0;
+
+  const start = gameState.player.health;
+  performAttack(gameState.player, monster);
+  if (gameState.player.health <= start) {
+    console.error('lifesteal did not heal');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- introduce new Vampiric/Leeching item affixes that grant life steal
- display life steal on item descriptions
- implement life steal healing when damaging enemies
- add regression test for life steal affix

## Testing
- `npm test` *(fails: mana.test.js)*
- `node tests/lifeStealAffix.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684bb66469688327ac2fceaa96d9235f