### PR TITLE
Update healer skill set

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1537,7 +1537,7 @@ const MERCENARY_NAMES = [
         const MERCENARY_SKILL_SETS = {
             WARRIOR: ['ChargeAttack', 'DoubleStrike'],
             ARCHER: ['DoubleStrike', 'HawkEye'],
-            HEALER: ['Heal', 'GuardianHymn'],
+            HEALER: ['Heal'],
             WIZARD: ['Fireball', 'Iceball']
         };
 


### PR DESCRIPTION
## Summary
- limit healer mercenary skill set to only `Heal`

## Testing
- `npm test` *(fails: `uniqueNovaProc.test.js` and `magicProjectile.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684bba1118b08327be551b70d753fb4a