### PR TITLE
Add kill bonus item effect

### DIFF
--- a/tests/killBonus.test.js
+++ b/tests/killBonus.test.js
@@ -1,0 +1,35 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+  win.Math.random = () => 0.99;
+
+  const { gameState, createMonster, killMonster } = win;
+
+  const weapon = win.createItem('shortSword', 0, 0);
+  weapon.killHealth = 2;
+  weapon.killMana = 1;
+  gameState.player.equipped.weapon = weapon;
+  gameState.player.health = 5;
+  gameState.player.mana = 0;
+
+  const monster = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  monster.health = 1;
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  monster.health = 0;
+  killMonster(monster, gameState.player);
+  if (gameState.player.health !== 7 || gameState.player.mana !== 1) {
+    console.error('kill bonuses not applied');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add kill bonus suffixes and apply bonuses when killing monsters
- display kill bonuses in item formatting
- add test covering kill bonus behaviour

## Testing
- `npm test` *(fails: mana.test.js and playerHealPurify.test.js)

------
https://chatgpt.com/codex/tasks/task_e_684bb75c02c0832787d8ece15976e38d