### PR TITLE
Add damage reflect stat

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1696,6 +1696,7 @@ const MERCENARY_NAMES = [
             { name: 'Refreshing', modifiers: { healthRegen: 1 } },
             { name: 'Mystic', modifiers: { manaRegen: 1 } },
             { name: 'Vampiric', modifiers: { lifeSteal: 0.05 } },
+            { name: 'Thorny', modifiers: { damageReflect: 0.1 } },
             { name: 'Venomous', modifiers: { status: 'poison' } },
             { name: 'Serrated', modifiers: { status: 'bleed' } },
             { name: 'Smoldering', modifiers: { status: 'burn' } },
@@ -1716,6 +1717,7 @@ const MERCENARY_NAMES = [
             { name: 'of Burning', modifiers: { status: 'burn' } },
             { name: 'of Frost', modifiers: { status: 'freeze' } },
             { name: 'of Leeching', modifiers: { lifeSteal: 0.05 } },
+            { name: 'of Thorns', modifiers: { damageReflect: 0.1 } },
             { name: 'of Poison Resistance', modifiers: { poisonResist: 0.3 } },
             { name: 'of Bleed Resistance', modifiers: { bleedResist: 0.3 } },
             { name: 'of Burn Resistance', modifiers: { burnResist: 0.3 } },
@@ -2215,6 +2217,15 @@ const MERCENARY_NAMES = [
 
             let damage = baseDamage + elementDamage;
             applyDamage(defender, damage);
+            const reflect = getStat(defender, 'damageReflect');
+            if (reflect > 0) {
+                const reflected = Math.floor(damage * reflect);
+                if (reflected > 0) {
+                    applyDamage(attacker, reflected);
+                    const attName = attacker === gameState.player ? '플레이어' : attacker.name;
+                    addMessage(`🔄 ${attName}이(가) ${formatNumber(reflected)} 피해를 반사로 입었습니다.`, 'combat');
+                }
+            }
             if (!crit) SoundEngine.playSound('takeDamage');
 
             const lifeSteal = getStat(attacker, 'lifeSteal');
@@ -2335,6 +2346,7 @@ const MERCENARY_NAMES = [
             if (item.burnResist !== undefined) stats.push(`화상저항+${formatNumber(item.burnResist * 100)}%`);
             if (item.freezeResist !== undefined) stats.push(`동결저항+${formatNumber(item.freezeResist * 100)}%`);
             if (item.lifeSteal !== undefined) stats.push(`흡혈+${formatNumber(item.lifeSteal * 100)}%`);
+            if (item.damageReflect !== undefined) stats.push(`피해반사+${formatNumber(item.damageReflect * 100)}%`);
             if (item.status) stats.push(`${item.status} 부여`);
             const levelText = item.enhanceLevel ? ` +Lv.${item.enhanceLevel}` : '';
             const name = formatItemName(item);

--- a/tests/damageReflect.test.js
+++ b/tests/damageReflect.test.js
@@ -1,0 +1,43 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createItem, gameState, createMonster, performAttack } = win;
+
+  const weapon = createItem('shortSword', 0, 0, 'Thorny');
+  if (weapon.prefix !== 'Thorny' || Math.abs(weapon.damageReflect - 0.1) > 1e-6) {
+    console.error('prefix not applied or incorrect value');
+    process.exit(1);
+  }
+
+  gameState.player.equipped.weapon = weapon;
+  const monster = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  win.rollDice = spec => {
+    if (spec === '1d20') return 20;
+    const m = /^1d(\d+)/.exec(spec);
+    if (m) return parseInt(m[1], 10);
+    return 1;
+  };
+  win.Math.random = () => 0.99;
+
+  const startHp = monster.health;
+  const result = performAttack(monster, gameState.player, { attackValue: 30, defenseValue: 0, damageDice: '1d4' });
+  const expected = Math.floor(result.damage * weapon.damageReflect);
+  if (monster.health !== startHp - expected) {
+    console.error('reflected damage incorrect');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/lifeStealAffix.test.js
+++ b/tests/lifeStealAffix.test.js
@@ -12,7 +12,7 @@ async function run() {
 
   const { createItem, formatItem, gameState, createMonster, performAttack, getStat } = win;
 
-  const seq = [0, 0, 0.55, 0, 0.65];
+  const seq = [0, 0, 0.525, 0, 0.65];
   const origRandom = win.Math.random;
   win.Math.random = () => seq.shift() ?? origRandom();
 

--- a/tests/prefixSuffix.test.js
+++ b/tests/prefixSuffix.test.js
@@ -11,7 +11,7 @@ async function run() {
 
   const { createItem, formatItem, PREFIXES, SUFFIXES } = win;
 
-  const seq = [0, 0, 0.45, 0, 0.25];
+  const seq = [0, 0, 0.42, 0, 0.25];
   const origRandom = win.Math.random;
   win.Math.random = () => seq.shift() ?? origRandom();
 


### PR DESCRIPTION
## Summary
- add `damageReflect` prefix and suffix modifiers
- show reflected damage in item descriptions
- implement reflection after attacks
- adjust prefix tests for new prefix counts
- add unit test covering reflected damage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bbc8c4cec8327bb9fe54893b918f6