### PR TITLE
Add sprite assets integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,10 +120,11 @@
         }
         .treasure {
             background: none;
-            background-image: url('assets/images/floor-tile.png');
-            background-size: cover;
-            background-position: center;
-            color: #8B4513;
+            background-image: url('assets/images/gold.png'), url('assets/images/floor-tile.png');
+            background-size: contain, cover;
+            background-position: center, center;
+            background-repeat: no-repeat, no-repeat;
+            color: transparent;
             box-shadow: 0 0 10px rgba(255, 215, 0, 0.7);
             animation: treasureSparkle 1s ease-in-out infinite alternate;
             font-size: 20px;
@@ -143,10 +144,11 @@
         }
         .chest {
             background: none;
-            background-image: url('assets/images/floor-tile.png');
-            background-size: cover;
-            background-position: center;
-            color: #fff;
+            background-image: url('assets/images/chest.png'), url('assets/images/floor-tile.png');
+            background-size: contain, cover;
+            background-position: center, center;
+            background-repeat: no-repeat, no-repeat;
+            color: transparent;
             font-size: 20px;
         }
         .mine {
@@ -221,10 +223,11 @@
         }
         .corpse {
             background: none;
-            background-image: url('assets/images/floor-tile.png');
-            background-size: cover;
-            background-position: center;
-            color: #ccc;
+            background-image: url('assets/images/corpse.png'), url('assets/images/floor-tile.png');
+            background-size: contain, cover;
+            background-position: center, center;
+            background-repeat: no-repeat, no-repeat;
+            color: transparent;
             font-size: 20px;
         }
         .exit {
@@ -587,6 +590,12 @@
             vertical-align: middle;
             image-rendering: pixelated;
         }
+        .inline-icon {
+            width: 16px;
+            height: 16px;
+            vertical-align: middle;
+            image-rendering: pixelated;
+        }
         .message.dialogue {
             color: #a7d8ff;
             background-color: #2a3a4a;
@@ -909,7 +918,7 @@
                 <div>🔮 마법공격: <span id="magicPower">0</span></div>
                 <div>✨ 마법방어: <span id="magicResist">0</span></div>
                 <div>⭐ 경험치: <span id="exp">0</span>/<span id="expNeeded">20</span></div>
-                <div>💰 골드: <span id="gold">0</span></div>
+                <div><img src="assets/images/gold.png" class="inline-icon"> 골드: <span id="gold">0</span></div>
                 <div>🏰 층: <span id="floor">1</span></div>
             </div>
             

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1144,7 +1144,8 @@ const MERCENARY_NAMES = [
                 damageDice: "1d6",
                 price: 10,
                 level: 1,
-                icon: '🗡️'
+                icon: '🗡️',
+                imageUrl: 'assets/images/shortsword.png'
             },
             longSword: {
                 name: '⚔️ 장검',
@@ -1154,6 +1155,16 @@ const MERCENARY_NAMES = [
                 damageDice: "1d8",
                 level: 2,
                 icon: '⚔️'
+            },
+            bow: {
+                name: '🏹 활',
+                type: ITEM_TYPES.WEAPON,
+                attack: 3,
+                damageDice: "1d6",
+                price: 20,
+                level: 1,
+                icon: '🏹',
+                imageUrl: 'assets/images/bow.png'
             },
             magicSword: {
                 name: '✨ 마법검',
@@ -1180,7 +1191,8 @@ const MERCENARY_NAMES = [
                 defense: 2,
                 price: 15,
                 level: 1,
-                icon: '🛡️'
+                icon: '🛡️',
+                imageUrl: 'assets/images/leatherarmor.png'
             },
             chainMail: {
                 name: '🔗 사슬 갑옷',
@@ -2599,7 +2611,11 @@ const MERCENARY_NAMES = [
                 div.className = 'inventory-item';
                 const span = document.createElement('span');
                 const label = count > 1 ? `${formatItem(item)} x ${count}` : formatItem(item);
-                span.innerHTML = label;
+                if (item.imageUrl) {
+                    span.innerHTML = `<img src="${item.imageUrl}" class="inline-icon" style="margin-right:4px;">${label}`;
+                } else {
+                    span.innerHTML = label;
+                }
                 div.appendChild(span);
                 div.onclick = () => handleItemClick(item);
                 if (item.type !== ITEM_TYPES.WEAPON && item.type !== ITEM_TYPES.ARMOR && item.type !== ITEM_TYPES.ACCESSORY) {
@@ -2617,7 +2633,9 @@ const MERCENARY_NAMES = [
 
             const weaponSlot = document.getElementById('equipped-weapon');
             if (gameState.player.equipped.weapon) {
-                weaponSlot.innerHTML = `무기: ${formatItem(gameState.player.equipped.weapon)}`;
+                const w = gameState.player.equipped.weapon;
+                const prefix = w.imageUrl ? `<img src="${w.imageUrl}" class="inline-icon" style="margin-right:4px;">` : '';
+                weaponSlot.innerHTML = `무기: ${prefix}${formatItem(w)}`;
                 weaponSlot.onclick = unequipWeapon;
             } else {
                 weaponSlot.textContent = '무기: 없음';
@@ -2625,7 +2643,9 @@ const MERCENARY_NAMES = [
             }
             const armorSlot = document.getElementById('equipped-armor');
             if (gameState.player.equipped.armor) {
-                armorSlot.innerHTML = `방어구: ${formatItem(gameState.player.equipped.armor)}`;
+                const a = gameState.player.equipped.armor;
+                const prefix = a.imageUrl ? `<img src="${a.imageUrl}" class="inline-icon" style="margin-right:4px;">` : '';
+                armorSlot.innerHTML = `방어구: ${prefix}${formatItem(a)}`;
                 armorSlot.onclick = unequipArmor;
             } else {
                 armorSlot.textContent = '방어구: 없음';

--- a/style.css
+++ b/style.css
@@ -279,10 +279,11 @@
 /* 시체 셀 스타일 및 아이콘 표시 */
 .corpse {
     background: none;
-    background-image: url('assets/images/floor-tile.png');
-    background-size: cover;
-    background-position: center;
-    color: #ccc;
+    background-image: url('assets/images/corpse.png'), url('assets/images/floor-tile.png');
+    background-size: contain, cover;
+    background-position: center, center;
+    background-repeat: no-repeat, no-repeat;
+    color: transparent;
     /* 텍스트 아이콘이 중앙에 오도록 flex 속성 추가 */
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- add CSS icons for treasure, chest, and corpse tiles
- show gold image in stats panel
- add item images for short sword, bow, and leather armor
- render item icons in inventory and equipment slots
- use corpse sprite in stylesheet

## Testing
- `npm test` *(fails: mercenaryFollow.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684bc3c557048327b1333827c2cdcaa8