### PR TITLE
Fix lifeSteal test by boosting player attack

### DIFF
--- a/tests/lifeStealAffix.test.js
+++ b/tests/lifeStealAffix.test.js
@@ -40,6 +40,8 @@ async function run() {
   gameState.dungeon[monster.y][monster.x] = 'monster';
 
   gameState.player.health = 10;
+  // Boost player attack so life steal has damage to work with
+  gameState.player.strength = 20;
 
   win.rollDice = spec => {
     if (spec === '1d20') return 20;


### PR DESCRIPTION
## Summary
- tweak `lifeStealAffix.test.js` to give the player more strength before attacking

## Testing
- `node tests/lifeStealAffix.test.js`
- `npm test` *(fails: magicProjectile.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bc57a3cac8327a69d2c2a3d7e6ed1