### PR TITLE
Refactor mercenary kill handling

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3758,17 +3758,27 @@ function findNearestEmpty(x, y) {
             return {x, y};
         }
 
-function killMonster(monster) {
+function killMonster(monster, killer) {
             let itemOnCorpse = false;
             SoundEngine.playSound('monsterDie'); // 몬스터 사망음 재생
             addMessage(`💀 ${monster.name}을(를) 처치했습니다!`, 'combat', null, getMonsterImage(monster));
-            gameState.player.exp += monster.exp;
-            let goldGain = monster.gold;
-            if (gameState.currentMapModifiers && gameState.currentMapModifiers.goldMultiplier) {
-                goldGain = Math.floor(goldGain * gameState.currentMapModifiers.goldMultiplier);
+            if (killer && killer !== gameState.player) {
+                const mercExp = Math.floor(monster.exp * 0.6);
+                const playerExp = Math.floor(monster.exp * 0.4);
+                killer.exp += mercExp;
+                gameState.player.exp += playerExp;
+                gameState.player.gold += monster.gold;
+                checkMercenaryLevelUp(killer);
+                checkLevelUp();
+            } else {
+                gameState.player.exp += monster.exp;
+                let goldGain = monster.gold;
+                if (gameState.currentMapModifiers && gameState.currentMapModifiers.goldMultiplier) {
+                    goldGain = Math.floor(goldGain * gameState.currentMapModifiers.goldMultiplier);
+                }
+                gameState.player.gold += goldGain;
+                checkLevelUp();
             }
-            gameState.player.gold += goldGain;
-            checkLevelUp();
             updateStats();
             if ((monster.special === 'boss' || monster.isChampion) && Math.random() < 0.10) {
                 const uniqueKeys = Object.keys(UNIQUE_ITEMS);
@@ -7156,54 +7166,7 @@ function processTurn() {
                         playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary", null, getMercImage(mercenary.type));
 
-                        const mercExp = Math.floor(nearestMonster.exp * 0.6);
-                        const playerExp = Math.floor(nearestMonster.exp * 0.4);
-
-                        mercenary.exp += mercExp;
-                        gameState.player.exp += playerExp;
-                        gameState.player.gold += nearestMonster.gold;
-
-                        checkMercenaryLevelUp(mercenary);
-                        checkLevelUp();
-                        updateStats();
-
-                        if (nearestMonster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
-                            if (Math.random() < 0.2) bossItems.push('reviveScroll');
-                            const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const bossItem = createItem(bossItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(bossItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
-                        } else if (Math.random() < nearestMonster.lootChance) {
-                            const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
-                            const availableItems = itemKeys.filter(key =>
-                                ITEMS[key].level <= Math.ceil(gameState.floor / 2 + 1) &&
-                                ITEMS[key].type !== ITEM_TYPES.ESSENCE
-                            );
-                            let randomItemKey = availableItems[Math.floor(Math.random() * availableItems.length)];
-                            if (Math.random() < 0.1 && ITEMS.reviveScroll.level <= Math.ceil(gameState.floor / 2 + 1)) {
-                                randomItemKey = 'reviveScroll';
-                            }
-
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const droppedItem = createItem(randomItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(droppedItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
-                        } else {
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
-                        }
-
-                        const monsterIndex = gameState.monsters.findIndex(m => m === nearestMonster);
-                        if (monsterIndex !== -1) {
-                            gameState.monsters.splice(monsterIndex, 1);
-                        }
-                        nearestMonster.health = 0;
-                        nearestMonster.turnsLeft = CORPSE_TURNS;
-                        gameState.corpses.push(nearestMonster);
-                        gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
+                        killMonster(nearestMonster, mercenary);
                     }
                     mercenary.mana -= skillManaCost;
                     mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
@@ -7237,54 +7200,7 @@ function processTurn() {
                         playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary", null, getMercImage(mercenary.type));
 
-                        const mercExp = Math.floor(nearestMonster.exp * 0.6);
-                        const playerExp = Math.floor(nearestMonster.exp * 0.4);
-
-                        mercenary.exp += mercExp;
-                        gameState.player.exp += playerExp;
-                        gameState.player.gold += nearestMonster.gold;
-
-                        checkMercenaryLevelUp(mercenary);
-                        checkLevelUp();
-                        updateStats();
-
-                        if (nearestMonster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
-                            if (Math.random() < 0.2) bossItems.push('reviveScroll');
-                            const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const bossItem = createItem(bossItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(bossItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
-                        } else if (Math.random() < nearestMonster.lootChance) {
-                            const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
-                            const availableItems = itemKeys.filter(key =>
-                                ITEMS[key].level <= Math.ceil(gameState.floor / 2 + 1) &&
-                                ITEMS[key].type !== ITEM_TYPES.ESSENCE
-                            );
-                            let randomItemKey = availableItems[Math.floor(Math.random() * availableItems.length)];
-                            if (Math.random() < 0.1 && ITEMS.reviveScroll.level <= Math.ceil(gameState.floor / 2 + 1)) {
-                                randomItemKey = 'reviveScroll';
-                            }
-
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const droppedItem = createItem(randomItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(droppedItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
-                        } else {
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
-                        }
-
-                        const monsterIndex = gameState.monsters.findIndex(m => m === nearestMonster);
-                        if (monsterIndex !== -1) {
-                            gameState.monsters.splice(monsterIndex, 1);
-                        }
-                        nearestMonster.health = 0;
-                        nearestMonster.turnsLeft = CORPSE_TURNS;
-                        gameState.corpses.push(nearestMonster);
-                        gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
+                        killMonster(nearestMonster, mercenary);
                     }
                     mercenary.mana -= skillManaCost;
                     mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
@@ -7327,54 +7243,7 @@ function processTurn() {
                         playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary", null, getMercImage(mercenary.type));
 
-                        const mercExp = Math.floor(nearestMonster.exp * 0.6);
-                        const playerExp = Math.floor(nearestMonster.exp * 0.4);
-
-                        mercenary.exp += mercExp;
-                        gameState.player.exp += playerExp;
-                        gameState.player.gold += nearestMonster.gold;
-
-                        checkMercenaryLevelUp(mercenary);
-                        checkLevelUp();
-                        updateStats();
-
-                        if (nearestMonster.special === 'boss') {
-                            const bossItems = ['magicSword', 'plateArmor', 'greaterHealthPotion'];
-                            if (Math.random() < 0.2) bossItems.push('reviveScroll');
-                            const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const bossItem = createItem(bossItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(bossItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
-                        } else if (Math.random() < nearestMonster.lootChance) {
-                            const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
-                            const availableItems = itemKeys.filter(key =>
-                                ITEMS[key].level <= Math.ceil(gameState.floor / 2 + 1) &&
-                                ITEMS[key].type !== ITEM_TYPES.ESSENCE
-                            );
-                            let randomItemKey = availableItems[Math.floor(Math.random() * availableItems.length)];
-                            if (Math.random() < 0.1 && ITEMS.reviveScroll.level <= Math.ceil(gameState.floor / 2 + 1)) {
-                                randomItemKey = 'reviveScroll';
-                            }
-
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const droppedItem = createItem(randomItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(droppedItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
-                        } else {
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
-                        }
-
-                        const monsterIndex = gameState.monsters.findIndex(m => m === nearestMonster);
-                        if (monsterIndex !== -1) {
-                            gameState.monsters.splice(monsterIndex, 1);
-                        }
-                        nearestMonster.health = 0;
-                        nearestMonster.turnsLeft = CORPSE_TURNS;
-                        gameState.corpses.push(nearestMonster);
-                        gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
+                        killMonster(nearestMonster, mercenary);
                     }
                     mercenary.mana -= skillManaCost;
                     mercenary.skillCooldowns[skillKey] = skillInfo.cooldown;
@@ -7413,54 +7282,7 @@ function processTurn() {
                         playRandomKillQuote(mercenary);
                         addMessage(`💀 ${mercenary.name}이(가) ${nearestMonster.name}을(를) 처치했습니다!`, "mercenary", null, getMercImage(mercenary.type));
                         
-                        const mercExp = Math.floor(nearestMonster.exp * 0.6);
-                        const playerExp = Math.floor(nearestMonster.exp * 0.4);
-                        
-                        mercenary.exp += mercExp;
-                        gameState.player.exp += playerExp;
-                        gameState.player.gold += nearestMonster.gold;
-                        
-                        checkMercenaryLevelUp(mercenary);
-                        checkLevelUp();
-                        updateStats();
-                        
-                        if (nearestMonster.special === 'boss') {
-                            const bossItems = ['magicSword', 'magicStaff', 'plateArmor', 'greaterHealthPotion'];
-                            if (Math.random() < 0.2) bossItems.push('reviveScroll');
-                            const bossItemKey = bossItems[Math.floor(Math.random() * bossItems.length)];
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const bossItem = createItem(bossItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(bossItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`🎁 ${nearestMonster.name}이(가) ${bossItem.name}을(를) 떨어뜨렸습니다!`, "treasure");
-                        } else if (Math.random() < nearestMonster.lootChance) {
-                            const itemKeys = Object.keys(ITEMS).filter(k => k !== 'reviveScroll');
-                            const availableItems = itemKeys.filter(key =>
-                                ITEMS[key].level <= Math.ceil(gameState.floor / 2 + 1) &&
-                                ITEMS[key].type !== ITEM_TYPES.ESSENCE
-                            );
-                            let randomItemKey = availableItems[Math.floor(Math.random() * availableItems.length)];
-                            if (Math.random() < 0.1 && ITEMS.reviveScroll.level <= Math.ceil(gameState.floor / 2 + 1)) {
-                                randomItemKey = 'reviveScroll';
-                            }
-
-                            const pos = findAdjacentEmpty(nearestMonster.x, nearestMonster.y);
-                            const droppedItem = createItem(randomItemKey, pos.x, pos.y, null, Math.floor(gameState.floor / 5));
-                            gameState.items.push(droppedItem);
-                            gameState.dungeon[pos.y][pos.x] = 'item';
-                            addMessage(`📦 ${nearestMonster.name}이(가) ${droppedItem.name}을(를) 떨어뜨렸습니다!`, "item");
-                        } else {
-                            gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'empty';
-                        }
-                        
-                        const monsterIndex = gameState.monsters.findIndex(m => m === nearestMonster);
-                        if (monsterIndex !== -1) {
-                            gameState.monsters.splice(monsterIndex, 1);
-                        }
-                        nearestMonster.health = 0;
-                        nearestMonster.turnsLeft = CORPSE_TURNS;
-                        gameState.corpses.push(nearestMonster);
-                        gameState.dungeon[nearestMonster.y][nearestMonster.x] = 'corpse';
+                        killMonster(nearestMonster, mercenary);
                     }
                     mercenary.hasActed = true;
                     return;

--- a/tests/mercenaryKillBonus.test.js
+++ b/tests/mercenaryKillBonus.test.js
@@ -1,0 +1,60 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    hireMercenary,
+    createMonster,
+    processMercenaryTurn,
+    gameState
+  } = win;
+
+  const size = 3;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.activeMercenaries = [];
+  gameState.player.x = 1;
+  gameState.player.y = 1;
+  gameState.dungeon[1][1] = 'empty';
+
+  gameState.player.gold = 500;
+  hireMercenary('WARRIOR');
+  const merc = gameState.activeMercenaries[0];
+  merc.attack = 50;
+  const monster = createMonster('GOBLIN', merc.x + 1, merc.y, 1);
+  monster.health = 1;
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  const playerExpBefore = gameState.player.exp;
+  const mercExpBefore = merc.exp;
+
+  const origRand = win.Math.random;
+  const origRoll = win.rollDice;
+  win.Math.random = () => 0;
+  win.rollDice = () => 20;
+  processMercenaryTurn(merc, gameState.monsters);
+  win.Math.random = origRand;
+  win.rollDice = origRoll;
+
+  const expectedMercGain = Math.floor(monster.exp * 0.6);
+  const expectedPlayerGain = Math.floor(monster.exp * 0.4);
+
+  if (merc.exp !== mercExpBefore + expectedMercGain ||
+      gameState.player.exp !== playerExpBefore + expectedPlayerGain) {
+    console.error('kill bonus not applied');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- allow `killMonster` to award exp/gold to mercenaries
- refactor `processMercenaryTurn` to use `killMonster` for monster deaths
- add test verifying mercenary kill bonuses

## Testing
- `npm test --silent` *(fails: `mana.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684bc57bc5d08327a74f580b6ac940f1