### PR TITLE
Add sprite rendering for item tiles

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4315,8 +4315,18 @@ function killMonster(monster) {
                                     updateUnitEffectIcons(m, div);
                                 }
                             } else if (baseCellType === 'item') {
-                                const it = gameState.items.find(it => it.x === x && it.y === y);
-                                if (it) div.textContent = it.icon;
+                                const item = gameState.items.find(it => it.x === x && it.y === y);
+                                if (item) {
+                                    if (item.imageUrl) {
+                                        div.style.backgroundImage = `url('${String(item.imageUrl)}'), url('assets/images/floor-tile.png')`;
+                                        div.style.backgroundSize = 'contain, cover';
+                                        div.style.backgroundPosition = 'center, center';
+                                        div.style.backgroundRepeat = 'no-repeat, no-repeat';
+                                        div.textContent = '';
+                                    } else {
+                                        div.textContent = item.icon;
+                                    }
+                                }
                             } else if (baseCellType === 'tile') {
                                 if (tileBg && mapTile) {
                                     tileBg.style.backgroundImage = `url('${String(mapTile.imageUrl)}')`;

--- a/style.css
+++ b/style.css
@@ -173,6 +173,15 @@
   background-image: url("assets/images/goblin-wizard.png"), url("assets/images/floor-tile.png");
 }
 
+/* Item sprite styling */
+.cell.item {
+  background-size: contain, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+  background-color: transparent;
+  image-rendering: pixelated;
+}
+
 /* ---- Special unit glow effects ---- */
 .cell.elite {
   box-shadow: 0 0 8px rgba(244, 67, 54, 0.7);


### PR DESCRIPTION
## Summary
- render item images when items specify an image URL
- style `.cell.item` so item sprites display like other sprite cells

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684bc92a07f88327b377a9470d2e56f6