### PR TITLE
Implement bard hymn priority and magic-based healing

### DIFF
--- a/tests/bardHealMagic.test.js
+++ b/tests/bardHealMagic.test.js
@@ -1,0 +1,24 @@
+const { loadGame } = require('./helpers');
+const assert = require('assert');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { createMercenary, healTarget, gameState, getStat } = win;
+
+  gameState.player.health = 10;
+  const bard = createMercenary('BARD', 1, 1);
+  bard.intelligence = 5;
+  const expected = Math.min(getStat(bard, 'magicPower'), getStat(gameState.player, 'maxHealth') - gameState.player.health);
+  healTarget(bard, gameState.player);
+  assert.strictEqual(gameState.player.health, 10 + expected, 'Bard heal should scale with magic power only');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/bardHymnPriority.test.js
+++ b/tests/bardHymnPriority.test.js
@@ -1,0 +1,53 @@
+const { loadGame } = require('./helpers');
+const assert = require('assert');
+
+async function run() {
+  const win = await loadGame();
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.updateSkillDisplay = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const {
+    createMercenary,
+    createMonster,
+    processMercenaryTurn,
+    gameState
+  } = win;
+  const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
+
+  const size = 5;
+  gameState.dungeonSize = size;
+  gameState.dungeon = Array.from({ length: size }, () => Array(size).fill('empty'));
+  gameState.fogOfWar = Array.from({ length: size }, () => Array(size).fill(false));
+  gameState.monsters = [];
+  gameState.player.x = 2;
+  gameState.player.y = 2;
+  gameState.dungeon[2][2] = 'empty';
+
+  const bard = createMercenary('BARD', 2, 1);
+  bard.skill = 'GuardianHymn';
+  bard.mana = bard.maxMana;
+  gameState.activeMercenaries.push(bard);
+
+  const ally = createMercenary('WARRIOR', 1, 1);
+  ally.health = ally.health - 1;
+  gameState.activeMercenaries.push(ally);
+
+  const monster = createMonster('GOBLIN', 2, 3, 1);
+  monster.alive = true;
+  gameState.monsters.push(monster);
+  gameState.dungeon[monster.y][monster.x] = 'monster';
+
+  const cost = MERCENARY_SKILLS[bard.skill].manaCost;
+  const beforeHealth = ally.health;
+  processMercenaryTurn(bard, gameState.monsters);
+
+  assert.strictEqual(ally.health, beforeHealth, 'Bard should prioritize hymn over healing');
+  assert.strictEqual(bard.mana, bard.maxMana - cost, 'Bard should cast hymn when enemy is in sight');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- ensure bard casts hymns first when enemies are visible
- base bard healing on magic power only
- add regression tests for bard hymn priority and magic-scaling healing

## Testing
- `node tests/bardHymnPriority.test.js`
- `node tests/bardHealMagic.test.js`
- `node tests/healSelf.test.js`
- `node tests/bardSkillProbability.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684bde624a2083279e6651baaa5e4d65