### PR TITLE
Lighten UI backgrounds to beige

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
         }
         :root {
             --cell-width: 32px;
+            --panel-bg: #f5f5dc;
+            --slot-bg: #f7ead9;
         }
         .dungeon {
             position: absolute;
@@ -303,7 +305,7 @@
         }
 
         .stats {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -325,7 +327,7 @@
             font-size: 13px;
         }
         .mercenary-panel {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -348,7 +350,7 @@
             color: #ddd;
         }
         .mercenary-info {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 8px;
             margin-bottom: 8px;
             border-radius: 6px;
@@ -356,7 +358,7 @@
             border-left: 3px solid #2196F3;
         }
         .mercenary-info.alive {
-            background-color: #444;
+            background-color: var(--slot-bg);
             border-left: 3px solid #2196F3;
         }
         .mercenary-info.dead {
@@ -365,7 +367,7 @@
             border-left: 3px solid #f44336;
         }
         .hire-panel {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -375,7 +377,7 @@
             font-weight: bold;
         }
         .incubator-panel {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -395,7 +397,7 @@
             font-size: 16px;
         }
         .incubator-slot {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
@@ -433,7 +435,7 @@
             transform: none;
         }
         .inventory {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -458,7 +460,7 @@
             font-size: 14px;
         }
         .skills-panel {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -478,7 +480,7 @@
             font-size: 16px;
         }
         .skill-item {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
@@ -494,7 +496,7 @@
             padding: 2px 4px;
         }
         .materials-panel {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -514,14 +516,14 @@
             font-size: 16px;
         }
         .recipe-item {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
             font-size: 11px;
         }
         .inventory-slot {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
@@ -534,7 +536,7 @@
             font-size: 11px;
         }
         .inventory-item {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
@@ -549,7 +551,7 @@
             transform: translateX(3px);
         }
         .equipped-slot {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
@@ -562,7 +564,7 @@
             border-left: 3px solid #666;
         }
         .message-log {
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 12px;
             border-radius: 8px;
@@ -581,7 +583,7 @@
             font-size: 12px;
         }
         .message.info {
-            background-color: #444;
+            background-color: var(--slot-bg);
             border-left-color: #2196F3;
         }
         .message.combat {
@@ -594,7 +596,7 @@
             color: #eee;
         }
         .message.unique-skill {
-            background-color: #2a2a2a;
+            background-color: var(--slot-bg);
             border-left-color: #FFD700;
         }
         .message.item {
@@ -674,7 +676,7 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: linear-gradient(135deg, #2a2a2a, #1a1a1a);
+            background: linear-gradient(135deg, var(--panel-bg), #c8bfa7);
             border: 3px solid #f44336;
             padding: 30px;
             border-radius: 12px;
@@ -708,7 +710,7 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -729,7 +731,7 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #2a2a2a url('assets/images/ui-bg.png');
+            background: var(--panel-bg) url('assets/images/ui-bg.png');
             background-size: cover;
             padding: 15px;
             border-radius: 8px;
@@ -747,7 +749,7 @@
             text-align: center;
         }
         .shop-item {
-            background-color: #444;
+            background-color: var(--slot-bg);
             padding: 6px;
             margin-bottom: 4px;
             border-radius: 4px;
@@ -786,7 +788,7 @@
         .bar {
             width: 100%;
             height: 10px;
-            background-color: #444;
+            background-color: var(--slot-bg);
             border-radius: 4px;
             margin-bottom: 4px;
             overflow: hidden;

--- a/style.css
+++ b/style.css
@@ -1,3 +1,8 @@
+:root {
+  --panel-bg: #f5f5dc;
+  --slot-bg: #f7ead9;
+}
+
 .player {
   /* background-image: url("assets/images/player.png"); */
   /* background-size: cover; */
@@ -204,7 +209,7 @@
 .inv-filter-btn {
   padding: 4px 8px;
   border: 1px solid #777;
-  background-color: #444;
+  background-color: var(--slot-bg);
   color: #ddd;
   cursor: pointer;
   border-radius: 4px;
@@ -248,7 +253,7 @@
     text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.9);
 }
 .tile-tab-container {
-  background: linear-gradient(135deg, #2a2a2a, #333);
+  background: linear-gradient(135deg, var(--panel-bg), #ddd);
   padding: 15px;
   border-radius: 8px;
   border: 1px solid #555;
@@ -312,7 +317,7 @@
 .tile-tab-container {
     width: 100%;
     max-width: 1400px;
-    background: linear-gradient(135deg, #2a2a2a, #333);
+    background: linear-gradient(135deg, var(--panel-bg), #ddd);
     padding: 10px;
     border-radius: 8px;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
@@ -342,7 +347,7 @@
     width: 48px;
     height: 48px;
     background-color: #1a1a1a;
-    border: 1px solid #444;
+    border: 1px solid var(--slot-bg);
     border-radius: 4px;
     cursor: pointer;
     background-size: cover;


### PR DESCRIPTION
## Summary
- add `--panel-bg` and `--slot-bg` CSS variables for beige shades
- apply beige background to UI panels, slots and messages
- update game over panel and tile tab container gradients

## Testing
- `npm test` *(fails: tests require environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684be1b3fc7c83278918a03d270e7873