### PR TITLE
Enhance battle log readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
             --cell-width: 32px;
             --panel-bg: #f5f5dc;
             --slot-bg: #f7ead9;
+            --log-text-color: #111;
         }
         .dungeon {
             position: absolute;
@@ -311,7 +312,7 @@
             border-radius: 8px;
             box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
             border: 1px solid #555;
-            color: #111;
+            color: var(--log-text-color);
             font-weight: bold;
         }
         .stats h2 {
@@ -1024,5 +1025,23 @@
     <script type="module" src="src/state.js"></script>
     <script type="module" src="src/ui.js"></script>
     <script type="module" src="src/mechanics.js"></script>
+    <script>
+        function updateLogTextColor() {
+            const styles = getComputedStyle(document.documentElement);
+            let bg = styles.getPropertyValue('--panel-bg').trim();
+            if (bg.startsWith('#')) {
+                if (bg.length === 4) {
+                    bg = '#' + bg[1] + bg[1] + bg[2] + bg[2] + bg[3] + bg[3];
+                }
+                const r = parseInt(bg.slice(1, 3), 16);
+                const g = parseInt(bg.slice(3, 5), 16);
+                const b = parseInt(bg.slice(5, 7), 16);
+                const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                const color = brightness < 128 ? '#eee' : '#111';
+                document.documentElement.style.setProperty('--log-text-color', color);
+            }
+        }
+        document.addEventListener('DOMContentLoaded', updateLogTextColor);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust message log color dynamically based on background brightness
- new CSS variable `--log-text-color` in `:root`
- compute text color at runtime via script

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684be9a6cc1083278c6fdd5a6207f51e