### PR TITLE
Fix bard skills

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1579,7 +1579,7 @@ const MERCENARY_NAMES = [
             ARCHER: ['DoubleStrike', 'HawkEye'],
             HEALER: ['Heal'],
             WIZARD: ['Fireball', 'Iceball'],
-            BARD: ['GuardianHymn', 'CourageHymn']
+            BARD: ['GuardianHymn', 'CourageHymn', 'Heal']
         };
 
         const MONSTER_SKILL_SETS = {
@@ -5154,8 +5154,15 @@ function killMonster(monster, killer = null) {
             const mercType = MERCENARY_TYPES[type];
             const skillPool = MERCENARY_SKILL_SETS[type] || [];
             const isTestMerc = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
-            const assignedSkill = skillPool.length ? (isTestMerc ? skillPool[0] : skillPool[Math.floor(Math.random() * skillPool.length)]) : null;
-            const assignedSkill2 = type === 'HEALER' ? 'Purify' : null;
+            let assignedSkill;
+            if (type === 'BARD') {
+                const hymns = skillPool.filter(s => s !== 'Heal');
+                assignedSkill = hymns.length ? (isTestMerc ? hymns[0] : hymns[Math.floor(Math.random() * hymns.length)]) : null;
+            } else {
+                assignedSkill = skillPool.length ? (isTestMerc ? skillPool[0] : skillPool[Math.floor(Math.random() * skillPool.length)]) : null;
+            }
+            let assignedSkill2 = type === 'HEALER' ? 'Purify' : null;
+            if (type === 'BARD') assignedSkill2 = 'Heal';
             const randomBaseName = MERCENARY_NAMES[Math.floor(Math.random() * MERCENARY_NAMES.length)];
             const jobLabel = mercType.name.split(' ')[1] || mercType.name;
             const name = `${randomBaseName} (${jobLabel})`;

--- a/tests/bardHealMagic.test.js
+++ b/tests/bardHealMagic.test.js
@@ -15,6 +15,7 @@ async function run() {
 
   gameState.player.health = 10;
   const bard = createMercenary('BARD', 1, 1);
+  assert.strictEqual(bard.skill2, 'Heal', 'Bard should start with Heal as skill2');
   bard.intelligence = 5;
   const expected = Math.min(getStat(bard, 'magicPower'), getStat(gameState.player, 'maxHealth') - gameState.player.health);
   healTarget(bard, gameState.player);

--- a/tests/bardHymnPriority.test.js
+++ b/tests/bardHymnPriority.test.js
@@ -29,6 +29,7 @@ async function run() {
   gameState.dungeon[2][2] = 'empty';
 
   const bard = createMercenary('BARD', 2, 1);
+  assert.strictEqual(bard.skill2, 'Heal', 'Bard should start with Heal as skill2');
   bard.skill = 'GuardianHymn';
   bard.mana = bard.maxMana;
   gameState.activeMercenaries.push(bard);

--- a/tests/bardSkillProbability.test.js
+++ b/tests/bardSkillProbability.test.js
@@ -29,6 +29,7 @@ async function run() {
   gameState.dungeon[2][2] = 'empty';
 
   const bard = createMercenary('BARD', 2, 1);
+  assert.strictEqual(bard.skill2, 'Heal', 'Bard should start with Heal as skill2');
   bard.skill = 'GuardianHymn';
   bard.mana = bard.maxMana;
   bard.shield = 0;


### PR DESCRIPTION
## Summary
- include Heal in BARD skill set
- always give bards Heal as their second skill
- update bard tests to expect the new default

## Testing
- `node tests/bardHealMagic.test.js`
- `node tests/bardHymnPriority.test.js`
- `node tests/bardSkillProbability.test.js`
- `npm test` *(fails: magic projectile not scaled properly, damage reflect incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684bf0ec1f808327b43c2e28503f1c5e