### PR TITLE
Adjust enhancement scaling for special stats

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5633,6 +5633,15 @@ function killMonster(monster, killer = null) {
                     item[stat] = item.baseStats[stat] + item.enhanceLevel * 1;
                 } else if (stat.endsWith('Resist')) {
                     item[stat] = item.baseStats[stat] + item.enhanceLevel * 0.01;
+                } else if ([
+                    'damageReflect',
+                    'lifeSteal',
+                    'skillManaCostMult',
+                    'skillPowerMult',
+                    'skillRangeBonus',
+                    'skillCooldownMod'
+                ].includes(stat)) {
+                    item[stat] = item.baseStats[stat] + item.enhanceLevel * 0.1;
                 } else {
                     item[stat] = item.baseStats[stat] + item.enhanceLevel * 0.5;
                 }


### PR DESCRIPTION
## Summary
- reduce enhancement scaling for damage reflect, life steal, skill mana tweaks, range, cooldown

## Testing
- `npm test` *(fails: prefixSuffix.test.js: prefix or suffix not applied)*

------
https://chatgpt.com/codex/tasks/task_e_684bf827edd08327a0182aa0c47875ee