### PR TITLE
Fix skillPowerMult retrieval

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -2551,7 +2551,7 @@ const MERCENARY_NAMES = [
         }
 
         function getSkillPowerMult(unit) {
-            return 1 + getStat(unit, 'skillPowerMult');
+            return getStat(unit, 'skillPowerMult') || 1;
         }
 
         function showSkillDamage(owner, key, defs) {


### PR DESCRIPTION
## Summary
- tweak getSkillPowerMult so it uses the stat directly and defaults to 1

## Testing
- `npm test` *(fails: mana.test.js - mana not used or regenerated correctly)*

------
https://chatgpt.com/codex/tasks/task_e_684bfc7151588327951e789cc5bdfc9b