### PR TITLE
Add Paladin mercenary unit

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -68,6 +68,7 @@
         altarLocation: { x: 0, y: 0 },
         shopLocation: { x: 0, y: 0 },
         shopItems: [],
+        paladinSpawns: [],
         materials: { herb: 5, wood: 3, iron: 100, bone: 100, bread: 0, meat: 0, lettuce: 0 },
         knownRecipes: ['healthPotion', 'sandwich', 'salad'],
         activeRecipes: ['healthPotion', 'sandwich', 'salad'],

--- a/style.css
+++ b/style.css
@@ -86,6 +86,12 @@
   background-position: center, center;
   background-repeat: no-repeat, no-repeat;
  }
+.cell.empty.mercenary.paladin {
+  background-image: url("assets/images/holy_knight.png"), url("assets/images/floor-tile.png");
+  background-size: contain, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+ }
 
 /* Individual mercenary sprites */
 .mercenary.warrior {
@@ -105,6 +111,9 @@
 }
 .mercenary.bard {
   background-image: url("assets/images/bard.png");
+}
+.mercenary.paladin {
+  background-image: url("assets/images/holy_knight.png");
 }
 
 /* --- Mercenary Sprite Styling --- */
@@ -128,6 +137,9 @@
 }
 .cell.mercenary.bard {
   background-image: url('assets/images/bard.png');
+}
+.cell.mercenary.paladin {
+  background-image: url('assets/images/holy_knight.png');
 }
 
 /* --- 신규 몬스터 이미지 스타일 --- */

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const vm = require('vm');
 
 async function loadGame(options = {}) {
-  const { confirmReturn = true } = options;
+  const { confirmReturn = true, spawnPaladin = false } = options;
   const htmlPath = path.join(__dirname, '..', 'index.html');
   let html = fs.readFileSync(htmlPath, 'utf8');
   html = html.replace(/<link rel="stylesheet" href="style.css">/, '');
@@ -17,6 +17,7 @@ async function loadGame(options = {}) {
     beforeParse(window) {
       window.rollDice = rollDice;
       window.confirm = () => confirmReturn;
+      window.spawnPaladinTest = spawnPaladin;
     }
   });
 

--- a/tests/paladinHire.test.js
+++ b/tests/paladinHire.test.js
@@ -1,0 +1,27 @@
+const { loadGame } = require('./helpers');
+
+async function run() {
+  const win = await loadGame({ spawnPaladin: true });
+  win.updateStats = () => {};
+  win.updateMercenaryDisplay = () => {};
+  win.updateInventoryDisplay = () => {};
+  win.renderDungeon = () => {};
+  win.updateCamera = () => {};
+  win.requestAnimationFrame = fn => fn();
+
+  const { gameState, movePlayer } = win;
+  const spawn = gameState.paladinSpawns[0];
+  if (!spawn) {
+    console.error('paladin spawn missing');
+    process.exit(1);
+  }
+  gameState.player.gold = spawn.cost || 1;
+  win.confirm = () => true;
+  movePlayer(spawn.x - gameState.player.x, spawn.y - gameState.player.y);
+  if (!gameState.activeMercenaries.some(m => m.type === 'PALADIN')) {
+    console.error('paladin not hired');
+    process.exit(1);
+  }
+}
+
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- introduce the Paladin mercenary with new stats and idle quotes
- allow Paladin to appear rarely in dungeons
- enable hiring Paladin from the map
- place a Paladin near the player in test mode
- update helper to control Paladin spawning
- add CSS sprites and images
- include a Paladin hire test

## Testing
- `npm test` *(fails: reflected damage incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684c313dd124832795d535219f159859