### PR TITLE
Disable starting map spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ Incubators let you hatch monster eggs into powerful allies. Place an egg from yo
 ### Loot
 
 Recipe scrolls may drop from monsters or appear in dungeons. Picking one up automatically adds the recipe to your known list. Duplicate scrolls are ignored once learned.
-At the start of a new game, three low-tier map items appear near the player.
 
 ### Monster Farming
 

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -8921,7 +8921,7 @@ function processTurn() {
             for (let i = 0; i < 5; i++) {
                 gameState.player.inventory.push(createItem('smallExpScroll', 0, 0));
             }
-            spawnStartingMaps();
+            // spawnStartingMaps();
             updateInventoryDisplay();
             updateSkillDisplay();
             updateIncubatorDisplay();


### PR DESCRIPTION
## Summary
- stop spawning maps at the start of a new game
- update docs about early maps

## Testing
- `node runTests.js` *(fails: playerHealPurify.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c3bd0440c8327b913221052145644