### PR TITLE
Fix paladin spawn render

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -8913,6 +8913,7 @@ function processTurn() {
                     const pal = createMercenary('PALADIN', palPos.x, palPos.y);
                     gameState.paladinSpawns.push({ x: palPos.x, y: palPos.y, mercenary: pal, cost: 1 });
                     gameState.dungeon[palPos.y][palPos.x] = 'paladin';
+                    renderDungeon();
                 }
             }
             for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
## Summary
- render the map again when spawning a paladin near the player so the cell is visible

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c457f7bb883278883846116e23b4d