### PR TITLE
Fix paladin spawn test variable

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -8884,6 +8884,7 @@ function processTurn() {
 
         function startGame() {
             // SoundEngine.initialize(); // 오디오 초기화는 사용자 입력 후 수행
+            globalThis.spawnPaladinTest = true;
             gameState.player.job = null;
             // Ensure player starts with initial gold
             gameState.player.gold = 1000;


### PR DESCRIPTION
## Summary
- ensure `spawnPaladinTest` defaults to true when starting a new game

## Testing
- `node tests/healOnKillAffix.test.js`
- `npm test` *(fails: healOnKillAffix.test.js not applied; process hung)*

------
https://chatgpt.com/codex/tasks/task_e_684c497e2bac8327a63127afcf4ff386