### PR TITLE
Add effectCycleState and player id

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -4,6 +4,9 @@
     const CELL_SIZE = 33;     // 셀 크기(갭 포함)
     const CELL_WIDTH = CELL_SIZE - 1; // 실제 셀 너비
 
+    // 효과 사이클 관리를 위한 상태
+    const effectCycleState = {};
+
     let gameState = {
         turn: 0,
         gameRunning: true,
@@ -12,6 +15,7 @@
         fogOfWar: [],
         cellElements: [],
         player: {
+            id: 'player',
             x: 1,
             y: 1,
             health: 20,
@@ -89,10 +93,11 @@
     global.FOG_RADIUS = FOG_RADIUS;
     global.CELL_SIZE = CELL_SIZE;
     global.CELL_WIDTH = CELL_WIDTH;
+    global.effectCycleState = effectCycleState;
     if (typeof document !== 'undefined') {
         document.documentElement.style.setProperty('--cell-width', `${CELL_WIDTH}px`);
     }
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH };
+        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH, effectCycleState };
     }
 })(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- introduce a new `effectCycleState` object for tracking effect cycles
- expose the new object globally and via module exports
- assign an `id` of `"player"` to the player object

## Testing
- `npm test` *(fails: prefixSuffix.test.js failed with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f136e548327b2d8267ac1f37b6f