### PR TITLE
Centralize regen logic in processTurn

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7252,10 +7252,17 @@ function processTurn() {
                 updateCamera();
                 renderDungeon();
             });
-            const hpRegen = getStat(gameState.player, 'healthRegen');
-            const mpRegen = getStat(gameState.player, 'manaRegen');
-            gameState.player.health = Math.min(getStat(gameState.player, 'maxHealth'), gameState.player.health + hpRegen);
-            gameState.player.mana = Math.min(getStat(gameState.player, 'maxMana'), gameState.player.mana + mpRegen);
+            const allPlayerUnits = [gameState.player, ...gameState.activeMercenaries.filter(m => m.alive)];
+            allPlayerUnits.forEach(unit => {
+                const hpRegen = getStat(unit, 'healthRegen');
+                const mpRegen = getStat(unit, 'manaRegen');
+                if (hpRegen > 0) {
+                    unit.health = Math.min(getStat(unit, 'maxHealth'), unit.health + hpRegen);
+                }
+                if (mpRegen > 0) {
+                    unit.mana = Math.min(getStat(unit, 'maxMana'), (unit.mana || 0) + mpRegen);
+                }
+            });
             updateStats();
             updateMercenaryDisplay();
             gameState.craftingQueue.forEach(entry => entry.turnsLeft--);
@@ -7435,10 +7442,6 @@ function processTurn() {
                 mercenary.bleedTurns--;
             }
 
-            const hpRegen = getStat(mercenary, 'healthRegen');
-            const mpRegen = getStat(mercenary, 'manaRegen');
-            mercenary.health = Math.min(getStat(mercenary, 'maxHealth'), mercenary.health + hpRegen);
-            mercenary.mana = Math.min(getStat(mercenary, 'maxMana'), mercenary.mana + mpRegen);
             
             // 장비 초기화 확인
             if (!mercenary.equipped) {

--- a/tests/mercenarySkillUpgrade.test.js
+++ b/tests/mercenarySkillUpgrade.test.js
@@ -62,8 +62,7 @@ async function run() {
   win.Math.random = () => 0;
   processMercenaryTurn(merc, gameState.monsters);
   win.Math.random = origRandom;
-  const startMana = Math.min(manaBefore + getStat(merc, 'manaRegen'), getStat(merc, 'maxMana'));
-  const manaExpected = startMana - (MERCENARY_SKILLS[skillKey].manaCost + healLevel - 1);
+  const manaExpected = manaBefore - (MERCENARY_SKILLS[skillKey].manaCost + healLevel - 1);
   assert.strictEqual(merc.mana, manaExpected, 'mana cost not scaled with level');
   const base = 3 + merc.level;
   const power = getStat(merc, 'magicPower');


### PR DESCRIPTION
## Summary
- remove health/mana regen from `processMercenaryTurn`
- centralize player and mercenary regeneration at the end of `processTurn`
- adjust mercenary skill upgrade test for new regen timing

## Testing
- `node tests/mercenarySkillUpgrade.test.js`
- `node runTests.js` *(fails: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_684c6763c6a0832798e0054d6215b4d3