### PR TITLE
Fix paladin hire and aura selection

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3728,7 +3728,7 @@ function updateMaterialsDisplay() {
             buffContainer.innerHTML = '';
             statusContainer.innerHTML = '';
 
-            if (!unit || !unit.id) return;
+            if (!unit || unit.id === undefined || unit.id === null) return;
 
             // 1. Collect aura, status and buff icons
             const auraIcons = getActiveAuraIcons(unit);
@@ -5357,7 +5357,8 @@ function killMonster(monster, killer = null) {
             if (type === 'BARD') assignedSkill2 = 'Heal';
             if (type === 'PALADIN') {
                 const paladinSet = MERCENARY_SKILL_SETS['PALADIN'] || [];
-                const keys = Object.keys(MERCENARY_SKILLS).filter(k => !paladinSet.includes(k));
+                const keys = Object.keys(MERCENARY_SKILLS)
+                    .filter(k => !paladinSet.includes(k) && !k.endsWith('Aura'));
                 assignedSkill2 = keys.length ? (isTestMerc ? keys[0] : keys[Math.floor(Math.random() * keys.length)]) : null;
             }
             const randomBaseName = MERCENARY_NAMES[Math.floor(Math.random() * MERCENARY_NAMES.length)];

--- a/tests/paladinHire.test.js
+++ b/tests/paladinHire.test.js
@@ -18,8 +18,13 @@ async function run() {
   gameState.player.gold = spawn.cost || 1;
   win.confirm = () => true;
   movePlayer(spawn.x - gameState.player.x, spawn.y - gameState.player.y);
-  if (!gameState.activeMercenaries.some(m => m.type === 'PALADIN')) {
+  const paladin = gameState.activeMercenaries.find(m => m.type === 'PALADIN');
+  if (!paladin) {
     console.error('paladin not hired');
+    process.exit(1);
+  }
+  if (paladin.skill2 && paladin.skill2.endsWith('Aura')) {
+    console.error('paladin second skill should not be an aura');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- exclude aura skills when picking the Paladin's second skill
- verify hired Paladins never receive aura skills
- tolerate empty IDs when updating unit effect icons

## Testing
- `npm test` *(fails: prefixSuffix.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c6330e32c8327a97c9b4f60f77457