### PR TITLE
Update superior test to reject debuff skills

### DIFF
--- a/tests/superior.test.js
+++ b/tests/superior.test.js
@@ -27,6 +27,11 @@ async function run() {
     console.error('skills not assigned');
     process.exit(1);
   }
+  const DEBUFFS = ['Weaken','Sunder','Regression','SpellWeakness','ElementalWeakness'];
+  if (DEBUFFS.includes(monster.skill)) {
+    console.error('debuff skill assigned');
+    process.exit(1);
+  }
   if (!monster.stars || Object.values(monster.stars).reduce((a,b)=>a+b,0) > 9) {
     console.error('invalid star values');
     process.exit(1);


### PR DESCRIPTION
## Summary
- validate that superior monsters never receive debuff-only skills

## Testing
- `node tests/superior.test.js`
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c633ff70c8327926ce365186df561