### PR TITLE
Expand champion skill pool

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5675,7 +5675,8 @@ function killMonster(monster, killer = null) {
             if (armorChoices.length) champion.equipped.armor = createItem(armorChoices[Math.floor(Math.random()*armorChoices.length)], 0, 0, null, enhanceLv);
             if (accChoices.length) champion.equipped.accessory1 = createItem(accChoices[Math.floor(Math.random()*accChoices.length)], 0, 0, null, enhanceLv);
 
-            const skillKeys = Object.keys(MONSTER_SKILLS);
+            const skillKeys = Object.keys(MONSTER_SKILLS)
+                .concat(['Weaken','Sunder','Regression','SpellWeakness','ElementalWeakness']);
             const sk = skillKeys[Math.floor(Math.random() * skillKeys.length)];
             champion.monsterSkill = sk;
             champion.skillLevels = {};

--- a/tests/champion.test.js
+++ b/tests/champion.test.js
@@ -12,6 +12,7 @@ async function run() {
 
   const { createChampion, killMonster, reviveMonsterCorpse, gameState, createItem } = win;
   const MONSTER_SKILLS = win.eval('MONSTER_SKILLS');
+  const EXTRA_SKILLS = ['Weaken','Sunder','Regression','SpellWeakness','ElementalWeakness'];
 
   const champ = createChampion('WARRIOR', 0, 0, 3);
   if (!champ.isChampion || champ.level !== 3) {
@@ -23,14 +24,18 @@ async function run() {
     console.error('champion stars invalid');
     process.exit(1);
   }
-  if (!MONSTER_SKILLS[champ.monsterSkill]) {
+  if (!MONSTER_SKILLS[champ.monsterSkill] && !EXTRA_SKILLS.includes(champ.monsterSkill)) {
     console.error('champion skill invalid');
     process.exit(1);
   }
 
   win.showChampionDetails(champ);
   const html = win.document.getElementById('monster-detail-content').innerHTML;
-  if (!html.includes('⭐'.repeat(champ.stars.strength)) || !html.includes(MONSTER_SKILLS[champ.monsterSkill].name)) {
+  if (!html.includes('⭐'.repeat(champ.stars.strength))) {
+    console.error('champion details missing info');
+    process.exit(1);
+  }
+  if (MONSTER_SKILLS[champ.monsterSkill] && !html.includes(MONSTER_SKILLS[champ.monsterSkill].name)) {
     console.error('champion details missing info');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- allow champions to pick from debuff skills
- update champion tests for new skill pool

## Testing
- `npm test` *(fails: `damageReflect.test.js` and `mana.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f1f250883279c632c864b5a279f