### PR TITLE
Fix champion skill info lookup

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3428,7 +3428,9 @@ function updateMaterialsDisplay() {
             const armor = eq.armor ? eq.armor.name : '없음';
             const acc1 = eq.accessory1 ? eq.accessory1.name : '없음';
             const acc2 = eq.accessory2 ? eq.accessory2.name : '없음';
-            const skillInfo = champion.monsterSkill ? MONSTER_SKILLS[champion.monsterSkill] : null;
+            const skillInfo = champion.monsterSkill
+                ? (MONSTER_SKILLS[champion.monsterSkill] || MERCENARY_SKILLS[champion.monsterSkill])
+                : null;
             let skillLine = '<div>스킬: 없음</div>';
             if (skillInfo) {
                 const lvl = champion.skillLevels && champion.skillLevels[champion.monsterSkill] || 1;


### PR DESCRIPTION
## Summary
- ensure champion detail panel can read from both monster and mercenary skills

## Testing
- `node runTests.js` *(fails: healSelf.test.js hangs)*

------
https://chatgpt.com/codex/tasks/task_e_684c7469f41083278c2bae15c65ae3b2