### PR TITLE
Update champion test skill validation

### DIFF
--- a/tests/champion.test.js
+++ b/tests/champion.test.js
@@ -12,7 +12,7 @@ async function run() {
 
   const { createChampion, killMonster, reviveMonsterCorpse, gameState, createItem } = win;
   const MONSTER_SKILLS = win.eval('MONSTER_SKILLS');
-  const EXTRA_SKILLS = ['Weaken','Sunder','Regression','SpellWeakness','ElementalWeakness'];
+  const MERCENARY_SKILLS = win.eval('MERCENARY_SKILLS');
 
   const champ = createChampion('WARRIOR', 0, 0, 3);
   if (!champ.isChampion || champ.level !== 3) {
@@ -24,7 +24,8 @@ async function run() {
     console.error('champion stars invalid');
     process.exit(1);
   }
-  if (!MONSTER_SKILLS[champ.monsterSkill] && !EXTRA_SKILLS.includes(champ.monsterSkill)) {
+  const skillInfo = MONSTER_SKILLS[champ.monsterSkill] || MERCENARY_SKILLS[champ.monsterSkill];
+  if (!skillInfo) {
     console.error('champion skill invalid');
     process.exit(1);
   }
@@ -35,7 +36,7 @@ async function run() {
     console.error('champion details missing info');
     process.exit(1);
   }
-  if (MONSTER_SKILLS[champ.monsterSkill] && !html.includes(MONSTER_SKILLS[champ.monsterSkill].name)) {
+  if (!html.includes(skillInfo.name)) {
     console.error('champion details missing info');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- load `MERCENARY_SKILLS` in champion test
- validate champion skill against both monster and mercenary skill data
- use `skillInfo.name` for details panel check

## Testing
- `node tests/champion.test.js`
- `npm test` *(fails: healOnKillAffix.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c7674feb48327ac918f4307ed4e2f