### PR TITLE
Add hero voice lines for key events

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -5,6 +5,8 @@
 
 // 전투가 발생했는지 추적하는 플래그
 let combatOccurredInTurn = false;
+let lowHpAlertPlayed = false;
+let lastDangerTurn = -1;
 
 /**
  * 지정된 경로의 오디오 파일을 재생하는 헬퍼 함수
@@ -33,6 +35,15 @@ function playRandomKillQuote(mercenary) {
         const index = Math.floor(Math.random() * data.killQuotes.length);
         playSoundFile(String(data.killQuotes[index]));
     }
+}
+
+function playPlayerKillQuote() {
+    const quotes = [
+        'assets/audio/player_kill_1.mp3',
+        'assets/audio/player_kill_2.mp3'
+    ];
+    const index = Math.floor(Math.random() * quotes.length);
+    playSoundFile(quotes[index]);
 }
 const SoundEngine = {
     audioContext: null,
@@ -425,12 +436,25 @@ function initializeAudio() {
 
     try {
         SoundEngine.initialize();
+        playSoundFile('assets/audio/player_start.mp3');
     } catch (err) {
         console.error("Audio initialization failed", err);
     }
     
     isAudioInitialized = true;
     console.log("All audio systems initialized by user action.");
+}
+
+function checkDanger() {
+    if (gameState.turn === lastDangerTurn) return;
+    const dangerNearby = gameState.monsters.some(m =>
+        (m.isChampion || m.isElite || m.isSuperior || m.special === 'boss') &&
+        getDistance(m.x, m.y, gameState.player.x, gameState.player.y) <= 5
+    );
+    if (dangerNearby) {
+        playSoundFile('assets/audio/player_danger.mp3');
+        lastDangerTurn = gameState.turn;
+    }
 }
 
 
@@ -3032,6 +3056,7 @@ function updateMaterialsDisplay() {
                 gameState.knownRecipes.push(key);
                 const name = RECIPES[key]?.name || key;
                 addMessage(`📖 ${name} 레시피를 배웠습니다!`, 'item');
+                playSoundFile('assets/audio/player_recipe.mp3');
 
                 // 상세 패널 UI 업데이트 함수를 여기서 직접 호출
                 updateCraftingDetailDisplay();
@@ -4050,6 +4075,7 @@ function killMonster(monster, killer = null) {
                 }
             } else {
                 addMessage(`💀 ${monster.name}을(를) 처치했습니다!`, 'combat', null, getMonsterImage(monster));
+                playPlayerKillQuote();
                 gameState.player.exp += monster.exp;
                 let goldGain = monster.gold;
                 if (gameState.currentMapModifiers && gameState.currentMapModifiers.goldMultiplier) {
@@ -4250,10 +4276,12 @@ function killMonster(monster, killer = null) {
                 gameState.player.gold -= cost;
                 gameState.activeMercenaries.push(mercenary);
                 addMessage(`🎉 ${corpse.name}을(를) 부활시켜 동료로 만들었습니다!`, 'mercenary');
+                playSoundFile('assets/audio/player_revive.mp3');
             } else if (gameState.standbyMercenaries.length < 5) {
                 gameState.player.gold -= cost;
                 gameState.standbyMercenaries.push(mercenary);
                 addMessage(`📋 부활한 ${corpse.name}을(를) 대기열에 추가했습니다.`, 'mercenary');
+                playSoundFile('assets/audio/player_revive.mp3');
             } else {
                 addMessage('❌ 용병이 가득 찼습니다.', 'info');
                 return;
@@ -6585,6 +6613,7 @@ function killMonster(monster, killer = null) {
                     if (item) {
                         addToInventory(item);
                         SoundEngine.playSound('getItem');
+                        playSoundFile('assets/audio/player_item.mp3');
                         addMessage(`📦 ${item.name}을(를) 획득했습니다!`, 'item');
 
                         const itemIndex = gameState.items.findIndex(i => i === item);
@@ -6638,6 +6667,7 @@ function killMonster(monster, killer = null) {
                 const treasure = gameState.treasures.find(t => t.x === newX && t.y === newY);
                 if (treasure) {
                     SoundEngine.playSound('treasure');
+                    playSoundFile('assets/audio/player_gold.mp3');
                     let gold = treasure.gold;
                     gameState.player.gold += gold;
                     addMessage(`💎 보물을 발견했습니다! ${formatNumber(gold)} 골드를 획득했습니다!`, "treasure");
@@ -6655,6 +6685,7 @@ function killMonster(monster, killer = null) {
                 if (item) {
                     addToInventory(item);
                     SoundEngine.playSound('getItem'); // 아이템 획득음 재생
+                    playSoundFile('assets/audio/player_item.mp3');
                     addMessage(`📦 ${item.name}을(를) 획득했습니다!`, 'item');
 
                     const itemIndex = gameState.items.findIndex(i => i === item);
@@ -6671,6 +6702,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'plant') {
                 SoundEngine.playSound('gatherMaterial');
+                playSoundFile('assets/audio/player_craft.mp3');
                 const materialsPool = ['herb', 'bread', 'meat', 'lettuce'];
                 const gained = [];
                 const count = Math.floor(Math.random() * 2) + 1;
@@ -6709,6 +6741,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'mine') {
                 SoundEngine.playSound('gatherMaterial');
+                playSoundFile('assets/audio/player_craft.mp3');
                 const qty = 5 + gameState.floor * 3;
                 if (!gameState.materials.iron) gameState.materials.iron = 0;
                 gameState.materials.iron += qty;
@@ -6719,6 +6752,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'tree') {
                 SoundEngine.playSound('gatherMaterial');
+                playSoundFile('assets/audio/player_craft.mp3');
                 const qty = 5 + gameState.floor * 3;
                 if (!gameState.materials.wood) gameState.materials.wood = 0;
                 gameState.materials.wood += qty;
@@ -6757,6 +6791,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'bones') {
                 SoundEngine.playSound('gatherMaterial');
+                playSoundFile('assets/audio/player_craft.mp3');
                 const qty = 5 + gameState.floor * 3;
                 if (!gameState.materials.bone) gameState.materials.bone = 0;
                 gameState.materials.bone += qty;
@@ -6806,6 +6841,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType.startsWith('temple')) {
                 SoundEngine.playSound('templeChime');
+                playSoundFile('assets/audio/player_temple.mp3');
                 if (cellType === 'templeHeal') {
                     gameState.player.health = getStat(gameState.player, 'maxHealth');
                     gameState.player.mana = getStat(gameState.player, 'maxMana');
@@ -6850,6 +6886,7 @@ function killMonster(monster, killer = null) {
                 return;
             }
 
+            checkDanger();
             processTurn();
         }
 
@@ -7300,6 +7337,14 @@ function processTurn() {
             advanceIncubators();
             updateIncubatorDisplay();
 
+            const hpRatio = gameState.player.health / getStat(gameState.player, 'maxHealth');
+            if (hpRatio < 0.25 && !lowHpAlertPlayed) {
+                playSoundFile('assets/audio/player_low_hp.mp3');
+                lowHpAlertPlayed = true;
+            } else if (hpRatio >= 0.25) {
+                lowHpAlertPlayed = false;
+            }
+
             // [추가된 유휴 대사 시스템]
             // 이번 턴에 전투가 없었고, 0.3% 확률을 통과했을 때 대사를 출력합니다.
             if (!combatOccurredInTurn && Math.random() < 0.003) {
@@ -7322,6 +7367,7 @@ function processTurn() {
 
         // 다음 턴을 위해 전투 발생 플래그를 리셋합니다.
         combatOccurredInTurn = false;
+        checkDanger();
     }
 
     function processPaladinTurn(mercenary, visibleMonsters = gameState.monsters) {
@@ -8729,19 +8775,23 @@ function processTurn() {
                 processTurn();
                 return;
             }
+            let gotItem = false;
             items.forEach(item => {
                 const idx = gameState.items.indexOf(item);
                 if (item.type === ITEM_TYPES.RECIPE_SCROLL) {
                     learnRecipe(item.recipe);
+                    gotItem = true;
                 } else {
                     addToInventory(item);
                     addMessage(`📦 ${item.name}을(를) 획득했습니다!`, 'item');
+                    gotItem = true;
                 }
                 if (idx !== -1) gameState.items.splice(idx, 1);
                 if (gameState.dungeon[item.y] && gameState.dungeon[item.y][item.x] === 'item') {
                     gameState.dungeon[item.y][item.x] = 'empty';
                 }
             });
+            if (gotItem) playSoundFile('assets/audio/player_item.mp3');
             renderDungeon();
             processTurn();
         }
@@ -8761,6 +8811,7 @@ function processTurn() {
 
         function showShop() {
             SoundEngine.playSound('openPanel');
+            playSoundFile('assets/audio/player_shop.mp3');
             updateShopDisplay();
             document.getElementById('shop-panel').style.display = 'block';
             gameState.gameRunning = false;


### PR DESCRIPTION
## Summary
- play hero voice line on adventure start and when health is low
- add hero kill quotes and danger detection
- voice cues for item pickup, treasure, materials and temples
- notify player when discovering recipes, shops or reviving monsters

## Testing
- `npm test` *(fails: playerHealPurify.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c8817684483279dd53ec77db0a9e9