### PR TITLE
Add random chance for player voice playback

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -37,13 +37,22 @@ function playRandomKillQuote(mercenary) {
     }
 }
 
+// 30% 확률로 플레이어 음성을 재생하는 헬퍼 함수
+function playPlayerVoice(filePath) {
+    if (Math.random() < 0.3) {
+        playSoundFile(filePath);
+    }
+}
+
 function playPlayerKillQuote() {
-    const quotes = [
-        'assets/audio/player_kill_1.mp3',
-        'assets/audio/player_kill_2.mp3'
-    ];
-    const index = Math.floor(Math.random() * quotes.length);
-    playSoundFile(quotes[index]);
+    if (Math.random() < 0.3) {
+        const quotes = [
+            'assets/audio/player_kill_1.mp3',
+            'assets/audio/player_kill_2.mp3'
+        ];
+        const index = Math.floor(Math.random() * quotes.length);
+        playSoundFile(quotes[index]);
+    }
 }
 const SoundEngine = {
     audioContext: null,
@@ -436,7 +445,7 @@ function initializeAudio() {
 
     try {
         SoundEngine.initialize();
-        playSoundFile('assets/audio/player_start.mp3');
+        playPlayerVoice('assets/audio/player_start.mp3');
     } catch (err) {
         console.error("Audio initialization failed", err);
     }
@@ -452,7 +461,7 @@ function checkDanger() {
         getDistance(m.x, m.y, gameState.player.x, gameState.player.y) <= 5
     );
     if (dangerNearby) {
-        playSoundFile('assets/audio/player_danger.mp3');
+        playPlayerVoice('assets/audio/player_danger.mp3');
         lastDangerTurn = gameState.turn;
     }
 }
@@ -3065,7 +3074,7 @@ function updateMaterialsDisplay() {
                 gameState.knownRecipes.push(key);
                 const name = RECIPES[key]?.name || key;
                 addMessage(`📖 ${name} 레시피를 배웠습니다!`, 'item');
-                playSoundFile('assets/audio/player_recipe.mp3');
+                playPlayerVoice('assets/audio/player_recipe.mp3');
 
                 // 상세 패널 UI 업데이트 함수를 여기서 직접 호출
                 updateCraftingDetailDisplay();
@@ -4284,12 +4293,12 @@ function killMonster(monster, killer = null) {
                 gameState.player.gold -= cost;
                 gameState.activeMercenaries.push(mercenary);
                 addMessage(`🎉 ${corpse.name}을(를) 부활시켜 동료로 만들었습니다!`, 'mercenary');
-                playSoundFile('assets/audio/player_revive.mp3');
+                playPlayerVoice('assets/audio/player_revive.mp3');
             } else if (gameState.standbyMercenaries.length < 5) {
                 gameState.player.gold -= cost;
                 gameState.standbyMercenaries.push(mercenary);
                 addMessage(`📋 부활한 ${corpse.name}을(를) 대기열에 추가했습니다.`, 'mercenary');
-                playSoundFile('assets/audio/player_revive.mp3');
+                playPlayerVoice('assets/audio/player_revive.mp3');
             } else {
                 addMessage('❌ 용병이 가득 찼습니다.', 'info');
                 return;
@@ -6624,7 +6633,7 @@ function killMonster(monster, killer = null) {
                     if (item) {
                         addToInventory(item);
                         SoundEngine.playSound('getItem');
-                        playSoundFile('assets/audio/player_item.mp3');
+                        playPlayerVoice('assets/audio/player_item.mp3');
                         addMessage(`📦 ${item.name}을(를) 획득했습니다!`, 'item');
 
                         const itemIndex = gameState.items.findIndex(i => i === item);
@@ -6678,7 +6687,7 @@ function killMonster(monster, killer = null) {
                 const treasure = gameState.treasures.find(t => t.x === newX && t.y === newY);
                 if (treasure) {
                     SoundEngine.playSound('treasure');
-                    playSoundFile('assets/audio/player_gold.mp3');
+                    playPlayerVoice('assets/audio/player_gold.mp3');
                     let gold = treasure.gold;
                     gameState.player.gold += gold;
                     addMessage(`💎 보물을 발견했습니다! ${formatNumber(gold)} 골드를 획득했습니다!`, "treasure");
@@ -6696,7 +6705,7 @@ function killMonster(monster, killer = null) {
                 if (item) {
                     addToInventory(item);
                     SoundEngine.playSound('getItem'); // 아이템 획득음 재생
-                    playSoundFile('assets/audio/player_item.mp3');
+                    playPlayerVoice('assets/audio/player_item.mp3');
                     addMessage(`📦 ${item.name}을(를) 획득했습니다!`, 'item');
 
                     const itemIndex = gameState.items.findIndex(i => i === item);
@@ -6713,7 +6722,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'plant') {
                 SoundEngine.playSound('gatherMaterial');
-                playSoundFile('assets/audio/player_craft.mp3');
+                playPlayerVoice('assets/audio/player_craft.mp3');
                 const materialsPool = ['herb', 'bread', 'meat', 'lettuce'];
                 const gained = [];
                 const count = Math.floor(Math.random() * 2) + 1;
@@ -6752,7 +6761,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'mine') {
                 SoundEngine.playSound('gatherMaterial');
-                playSoundFile('assets/audio/player_craft.mp3');
+                playPlayerVoice('assets/audio/player_craft.mp3');
                 const qty = 5 + gameState.floor * 3;
                 if (!gameState.materials.iron) gameState.materials.iron = 0;
                 gameState.materials.iron += qty;
@@ -6763,7 +6772,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'tree') {
                 SoundEngine.playSound('gatherMaterial');
-                playSoundFile('assets/audio/player_craft.mp3');
+                playPlayerVoice('assets/audio/player_craft.mp3');
                 const qty = 5 + gameState.floor * 3;
                 if (!gameState.materials.wood) gameState.materials.wood = 0;
                 gameState.materials.wood += qty;
@@ -6802,7 +6811,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType === 'bones') {
                 SoundEngine.playSound('gatherMaterial');
-                playSoundFile('assets/audio/player_craft.mp3');
+                playPlayerVoice('assets/audio/player_craft.mp3');
                 const qty = 5 + gameState.floor * 3;
                 if (!gameState.materials.bone) gameState.materials.bone = 0;
                 gameState.materials.bone += qty;
@@ -6852,7 +6861,7 @@ function killMonster(monster, killer = null) {
 
             if (cellType.startsWith('temple')) {
                 SoundEngine.playSound('templeChime');
-                playSoundFile('assets/audio/player_temple.mp3');
+                playPlayerVoice('assets/audio/player_temple.mp3');
                 if (cellType === 'templeHeal') {
                     gameState.player.health = getStat(gameState.player, 'maxHealth');
                     gameState.player.mana = getStat(gameState.player, 'maxMana');
@@ -7350,7 +7359,7 @@ function processTurn() {
 
             const hpRatio = gameState.player.health / getStat(gameState.player, 'maxHealth');
             if (hpRatio < 0.25 && !lowHpAlertPlayed) {
-                playSoundFile('assets/audio/player_low_hp.mp3');
+                playPlayerVoice('assets/audio/player_low_hp.mp3');
                 lowHpAlertPlayed = true;
             } else if (hpRatio >= 0.25) {
                 lowHpAlertPlayed = false;
@@ -8802,7 +8811,7 @@ function processTurn() {
                     gameState.dungeon[item.y][item.x] = 'empty';
                 }
             });
-            if (gotItem) playSoundFile('assets/audio/player_item.mp3');
+            if (gotItem) playPlayerVoice('assets/audio/player_item.mp3');
             renderDungeon();
             processTurn();
         }
@@ -8822,7 +8831,7 @@ function processTurn() {
 
         function showShop() {
             SoundEngine.playSound('openPanel');
-            playSoundFile('assets/audio/player_shop.mp3');
+            playPlayerVoice('assets/audio/player_shop.mp3');
             updateShopDisplay();
             document.getElementById('shop-panel').style.display = 'block';
             gameState.gameRunning = false;


### PR DESCRIPTION
## Summary
- wrap all player voice audio cues with `playPlayerVoice`
- only play voice lines 30% of the time

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684cf02dfe8c8327863c96248d8397f9