### PR TITLE
Update effect icon cycling

### DIFF
--- a/tests/effectIconsLayout.test.js
+++ b/tests/effectIconsLayout.test.js
@@ -36,7 +36,7 @@ async function run() {
     process.exit(1);
   }
 
-  if (buff.children.length !== 1 || status.children.length !== 0) {
+  if (buff.children.length !== 1 || status.children.length !== 1) {
     console.error('incorrect number of icons');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- update `updateUnitEffectIcons` to cycle buff and debuff icons separately
- update icon cycling interval for new state structure
- adjust test to expect debuff icon rendering

## Testing
- `node tests/effectIconsLayout.test.js`
- `node tests/healOnKillAffix.test.js`
- `npm test` *(fails: `healOnKillAffix.test.js` with 'heal on kill not applied')*

------
https://chatgpt.com/codex/tasks/task_e_684cf2ac6b2883278342562c28c1ad0f