### PR TITLE
Improve effect icon cycling

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3797,26 +3797,38 @@ function updateMaterialsDisplay() {
                 });
             }
 
-            const icons = [...auraIcons, ...statusIcons, ...buffIcons];
+            const buffs = [...auraIcons, ...buffIcons];
+            const debuffs = statusIcons;
 
             // 2. Update effectCycleState when icons change
-            if (icons.length === 0) {
+            if (buffs.length === 0 && debuffs.length === 0) {
                 delete effectCycleState[unit.id];
             } else {
                 const current = effectCycleState[unit.id];
-                const changed = !current || JSON.stringify(current.icons) !== JSON.stringify(icons);
+                const changed =
+                    !current ||
+                    JSON.stringify(current.buffs) !== JSON.stringify(buffs) ||
+                    JSON.stringify(current.debuffs) !== JSON.stringify(debuffs);
                 if (changed) {
-                    effectCycleState[unit.id] = { icons, currentIndex: 0 };
+                    effectCycleState[unit.id] = { buffs, debuffs, buffIndex: 0, debuffIndex: 0 };
                 }
             }
 
-            // 3. Render only the current icon
+            // 3. Render the currently indexed buff and debuff icons
             const state = effectCycleState[unit.id];
-            if (state && state.icons.length > 0) {
-                const iconSpan = document.createElement('span');
-                iconSpan.className = 'effect-icon';
-                iconSpan.textContent = state.icons[state.currentIndex];
-                buffContainer.appendChild(iconSpan);
+            if (state) {
+                if (state.buffs.length > 0) {
+                    const iconSpan = document.createElement('span');
+                    iconSpan.className = 'effect-icon';
+                    iconSpan.textContent = state.buffs[state.buffIndex];
+                    buffContainer.appendChild(iconSpan);
+                }
+                if (state.debuffs.length > 0) {
+                    const iconSpan = document.createElement('span');
+                    iconSpan.className = 'effect-icon';
+                    iconSpan.textContent = state.debuffs[state.debuffIndex];
+                    statusContainer.appendChild(iconSpan);
+                }
             }
         }
 
@@ -9328,10 +9340,14 @@ if (!(typeof navigator !== 'undefined' && navigator.userAgent &&
         let needsRender = false;
 
         allUnits.forEach(unit => {
-            if (unit && effectCycleState[unit.id]) {
-                const state = effectCycleState[unit.id];
-                if (state.icons.length > 1) { // 아이콘이 2개 이상일 때만 순환
-                    state.currentIndex = (state.currentIndex + 1) % state.icons.length;
+            const state = effectCycleState[unit.id];
+            if (state) {
+                if (state.buffs.length > 1) {
+                    state.buffIndex = (state.buffIndex + 1) % state.buffs.length;
+                    needsRender = true;
+                }
+                if (state.debuffs.length > 1) {
+                    state.debuffIndex = (state.debuffIndex + 1) % state.debuffs.length;
                     needsRender = true;
                 }
             }

--- a/tests/effectIconsLayout.test.js
+++ b/tests/effectIconsLayout.test.js
@@ -36,7 +36,7 @@ async function run() {
     process.exit(1);
   }
 
-  if (buff.children.length !== 1 || status.children.length !== 0) {
+  if (buff.children.length !== 1 || status.children.length !== 1) {
     console.error('incorrect number of icons');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- refactor `updateUnitEffectIcons` to track buff and debuff icons separately
- show buff and debuff icons in their own containers
- cycle through buff and debuff icons independently
- update layout test for the new icon logic

## Testing
- `node runTests.js` *(fails: `prefixSuffix.test.js`, `healOnKillAffix.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3a2351483279d46f8ca50146742