### PR TITLE
Remove background image from message log

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,8 +565,7 @@
             border-left: 3px solid #666;
         }
         .message-log {
-            background: var(--panel-bg) url('assets/images/ui-bg.png');
-            background-size: cover;
+            background: var(--panel-bg);
             padding: 12px;
             border-radius: 8px;
             height: 150px;


### PR DESCRIPTION
## Summary
- tweak `.message-log` to use a solid background color instead of a tiled image

## Testing
- `npm test` *(fails: monster aura icon missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d06cf307c8327b4fe8a84044f629a