### PR TITLE
Add elemental nova skills

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -1587,6 +1587,10 @@ const MERCENARY_NAMES = [
         const UNIQUE_EFFECT_POOL = [
             { event: 'onAttack', skill: 'FireNova', chance: 0.15 },
             { event: 'onAttack', skill: 'IceNova', chance: 0.15 },
+            { event: 'onAttack', skill: 'WindNova', chance: 0.15 },
+            { event: 'onAttack', skill: 'EarthNova', chance: 0.15 },
+            { event: 'onAttack', skill: 'LightNova', chance: 0.15 },
+            { event: 'onAttack', skill: 'DarkNova', chance: 0.15 },
             { event: 'onDamaged', skill: 'GuardianHymn', chance: 0.1 },
             { event: 'onDamaged', skill: 'CourageHymn', chance: 0.1 }
         ];
@@ -1598,6 +1602,10 @@ const MERCENARY_NAMES = [
             Iceball: { name: 'Iceball', icon: '❄️', damageDice: '1d8', range: 5, magic: true, element: 'ice', manaCost: 2, cooldown: 2 },
             FireNova: { name: 'Fire Nova', icon: '🔥', damageDice: '1d6', radius: 3, magic: true, element: 'fire', manaCost: 5, cooldown: 3, novaType: 'fire', screenShake: { intensity: 3, duration: 200 } },
             IceNova: { name: 'Ice Nova', icon: '❄️', damageDice: '1d6', radius: 3, magic: true, element: 'ice', manaCost: 4, cooldown: 3, novaType: 'ice' },
+            WindNova: { name: 'Wind Nova', icon: '💨', damageDice: '1d6', radius: 3, magic: true, element: 'wind', manaCost: 4, cooldown: 3, novaType: 'wind' },
+            EarthNova: { name: 'Earth Nova', icon: '🌱', damageDice: '1d6', radius: 3, magic: true, element: 'earth', manaCost: 4, cooldown: 3, novaType: 'earth' },
+            LightNova: { name: 'Light Nova', icon: '✨', damageDice: '1d6', radius: 3, magic: true, element: 'light', manaCost: 4, cooldown: 3, novaType: 'light' },
+            DarkNova: { name: 'Dark Nova', icon: '🌑', damageDice: '1d6', radius: 3, magic: true, element: 'dark', manaCost: 4, cooldown: 3, novaType: 'dark' },
             Heal: { name: 'Heal', icon: '💖', heal: 10, range: 2, manaCost: 3, cooldown: 2 },
             Purify: { name: 'Purify', icon: '🌀', purify: true, range: 2, manaCost: 2, cooldown: 2 },
             Teleport: { name: 'Teleport', icon: '🌀', teleport: true, manaCost: 2, cooldown: 1 },

--- a/tests/nova.test.js
+++ b/tests/nova.test.js
@@ -71,6 +71,106 @@ async function run() {
     console.error('ice nova incorrect', JSON.stringify(captured));
     process.exit(1);
   }
+
+  // Test Wind Nova
+  captured = [];
+  gameState.monsters = [];
+  gameState.dungeon[i1.y][i1.x] = 'empty';
+  gameState.dungeon[i2.y][i2.x] = 'empty';
+  const w1 = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  const w2 = createMonster('ZOMBIE', gameState.player.x, gameState.player.y + 2);
+  gameState.monsters.push(w1, w2);
+  gameState.dungeon[w1.y][w1.x] = 'monster';
+  gameState.dungeon[w2.y][w2.x] = 'monster';
+  gameState.player.skills.push('WindNova');
+  assignSkill(1, 'WindNova');
+  const windWeapon = createItem('shortSword', 0, 0);
+  windWeapon.windDamage = 2;
+  gameState.player.equipped.weapon = windWeapon;
+  win.rollDice = () => 6;
+  skill1Action();
+
+  const expectedWind = 6 + getStat(gameState.player, 'magicPower');
+  const relevantWind = captured.filter(c => c.element);
+  if (relevantWind.length !== 2 || relevantWind.some(c => c.attackValue !== expectedWind || c.element !== 'wind')) {
+    console.error('wind nova incorrect', JSON.stringify(captured));
+    process.exit(1);
+  }
+
+  // Test Earth Nova
+  captured = [];
+  gameState.monsters = [];
+  gameState.dungeon[w1.y][w1.x] = 'empty';
+  gameState.dungeon[w2.y][w2.x] = 'empty';
+  const e1 = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  const e2 = createMonster('ZOMBIE', gameState.player.x, gameState.player.y + 2);
+  gameState.monsters.push(e1, e2);
+  gameState.dungeon[e1.y][e1.x] = 'monster';
+  gameState.dungeon[e2.y][e2.x] = 'monster';
+  gameState.player.skills.push('EarthNova');
+  assignSkill(1, 'EarthNova');
+  const earthWeapon = createItem('shortSword', 0, 0);
+  earthWeapon.earthDamage = 2;
+  gameState.player.equipped.weapon = earthWeapon;
+  win.rollDice = () => 4;
+  skill1Action();
+
+  const expectedEarth = 4 + getStat(gameState.player, 'magicPower');
+  const relevantEarth = captured.filter(c => c.element);
+  if (relevantEarth.length !== 2 || relevantEarth.some(c => c.attackValue !== expectedEarth || c.element !== 'earth')) {
+    console.error('earth nova incorrect', JSON.stringify(captured));
+    process.exit(1);
+  }
+
+  // Test Light Nova
+  captured = [];
+  gameState.monsters = [];
+  gameState.dungeon[e1.y][e1.x] = 'empty';
+  gameState.dungeon[e2.y][e2.x] = 'empty';
+  const l1 = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  const l2 = createMonster('ZOMBIE', gameState.player.x, gameState.player.y + 2);
+  gameState.monsters.push(l1, l2);
+  gameState.dungeon[l1.y][l1.x] = 'monster';
+  gameState.dungeon[l2.y][l2.x] = 'monster';
+  gameState.player.skills.push('LightNova');
+  assignSkill(1, 'LightNova');
+  const lightWeapon = createItem('shortSword', 0, 0);
+  lightWeapon.lightDamage = 2;
+  gameState.player.equipped.weapon = lightWeapon;
+  win.rollDice = () => 5;
+  skill1Action();
+
+  const expectedLight = 5 + getStat(gameState.player, 'magicPower');
+  const relevantLight = captured.filter(c => c.element);
+  if (relevantLight.length !== 2 || relevantLight.some(c => c.attackValue !== expectedLight || c.element !== 'light')) {
+    console.error('light nova incorrect', JSON.stringify(captured));
+    process.exit(1);
+  }
+
+  // Test Dark Nova
+  captured = [];
+  gameState.monsters = [];
+  gameState.dungeon[l1.y][l1.x] = 'empty';
+  gameState.dungeon[l2.y][l2.x] = 'empty';
+  const d1 = createMonster('ZOMBIE', gameState.player.x + 1, gameState.player.y);
+  const d2 = createMonster('ZOMBIE', gameState.player.x, gameState.player.y + 2);
+  gameState.monsters.push(d1, d2);
+  gameState.dungeon[d1.y][d1.x] = 'monster';
+  gameState.dungeon[d2.y][d2.x] = 'monster';
+  gameState.player.skills.push('DarkNova');
+  assignSkill(1, 'DarkNova');
+  const darkWeapon = createItem('shortSword', 0, 0);
+  darkWeapon.darkDamage = 2;
+  gameState.player.equipped.weapon = darkWeapon;
+  win.rollDice = () => 6;
+  skill1Action();
+
+  const expectedDark = 6 + getStat(gameState.player, 'magicPower');
+  const relevantDark = captured.filter(c => c.element);
+  if (relevantDark.length !== 2 || relevantDark.some(c => c.attackValue !== expectedDark || c.element !== 'dark')) {
+    console.error('dark nova incorrect', JSON.stringify(captured));
+    process.exit(1);
+  }
 }
 
 run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- include four new nova skills in the skill set
- allow unique items to proc any elemental nova
- extend nova tests for Wind, Earth, Light and Dark Novas

## Testing
- `node runTests.js` *(fails: `manaOnKillAffix.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684d096ba2088327b5462fc7fe73a172