### PR TITLE
Centralize test environment check

### DIFF
--- a/index.html
+++ b/index.html
@@ -1031,6 +1031,7 @@
     </div>
     <audio id="bgm-player"></audio>
     <script src="dice.js"></script>
+    <script src="src/env.js"></script>
     <script type="module" src="src/state.js"></script>
     <script type="module" src="src/ui.js"></script>
     <script type="module" src="src/mechanics.js"></script>

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,12 @@
+(function(global){
+  function isTestEnvironment(){
+    return typeof navigator !== 'undefined' && navigator.userAgent &&
+      /Node\.js|jsdom/i.test(navigator.userAgent);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { isTestEnvironment };
+    global.isTestEnvironment = isTestEnvironment;
+  } else {
+    global.isTestEnvironment = isTestEnvironment;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -14,8 +14,7 @@ let lastDangerTurn = -1;
  */
 function playSoundFile(filePath) {
     if (!filePath) return;
-    if (typeof navigator !== 'undefined' && navigator.userAgent &&
-        (navigator.userAgent.includes('Node.js') || navigator.userAgent.includes('jsdom'))) {
+    if (typeof isTestEnvironment === 'function' && isTestEnvironment()) {
         return;
     }
     if (typeof Audio !== 'undefined') {
@@ -437,7 +436,7 @@ let isAudioInitialized = false;
  */
 function initializeAudio() {
     if (isAudioInitialized) return;
-    if (typeof navigator !== 'undefined' && navigator.userAgent && (navigator.userAgent.includes('Node.js') || navigator.userAgent.includes('jsdom'))) {
+    if (typeof isTestEnvironment === 'function' && isTestEnvironment()) {
         // Skip audio initialization in testing environments like jsdom
         isAudioInitialized = true;
         return;
@@ -5024,7 +5023,7 @@ function killMonster(monster, killer = null) {
                 const starterPotion = createItem('healthPotion', 0, 0);
                 gameState.player.inventory.push(starterPotion);
 
-                const isTestEnv = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+                const isTestEnv = typeof isTestEnvironment === 'function' && isTestEnvironment();
                 gameState.player.equipped.weapon = createItem('volcanicEruptor', 0, 0, null, 0, !isTestEnv);
                 gameState.player.equipped.armor = createItem('glacialGuard', 0, 0, null, 0, !isTestEnv);
                 gameState.player.equipped.accessory1 = createItem('guardianAmulet', 0, 0, null, 0, !isTestEnv);
@@ -5176,7 +5175,7 @@ function killMonster(monster, killer = null) {
                 gameState.dungeon[y][x] = 'plant';
             }
 
-            const isTestEnv = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+            const isTestEnv = typeof isTestEnvironment === 'function' && isTestEnvironment();
             if (!isTestEnv) {
                 const chestCount = 1 + Math.floor(Math.random() * 2);
                 for (let i = 0; i < chestCount; i++) {
@@ -5451,7 +5450,7 @@ function killMonster(monster, killer = null) {
         function createMercenary(type, x, y) {
             const mercType = MERCENARY_TYPES[type];
             const skillPool = MERCENARY_SKILL_SETS[type] || [];
-            const isTestMerc = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+            const isTestMerc = typeof isTestEnvironment === 'function' && isTestEnvironment();
             let assignedSkill;
             if (type === 'BARD') {
                 const hymns = skillPool.filter(s => s !== 'Heal');
@@ -5675,7 +5674,7 @@ function killMonster(monster, killer = null) {
             }
 
             if (item.tier === 'unique') {
-                const isTest = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+                const isTest = typeof isTestEnvironment === 'function' && isTestEnvironment();
                 if (!isTest) {
                     const effect = UNIQUE_EFFECT_POOL[Math.floor(Math.random() * UNIQUE_EFFECT_POOL.length)];
                     if (effect) {
@@ -5980,8 +5979,7 @@ function killMonster(monster, killer = null) {
                 }
             }
             let failChance = 0.2;
-            if (typeof navigator !== 'undefined' && navigator.userAgent &&
-                (navigator.userAgent.includes('Node.js') || navigator.userAgent.includes('jsdom'))) {
+            if (typeof isTestEnvironment === 'function' && isTestEnvironment()) {
                 failChance = 0; // deterministic success during tests
             }
 
@@ -7158,7 +7156,7 @@ function processTurn() {
                     m.affinity = Math.min(200, (m.affinity || 0) + AFFINITY_PER_TURN);
                 }
             });
-            const isTestEnv = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+            const isTestEnv = typeof isTestEnvironment === 'function' && isTestEnvironment();
             if (!isTestEnv) processProjectiles();
 
             if (applyStatusEffects(gameState.player)) {
@@ -8593,7 +8591,7 @@ function processTurn() {
                 createScreenShake(skill.screenShake.intensity, skill.screenShake.duration);
             }
 
-            const isTestEnv = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+            const isTestEnv = typeof isTestEnvironment === 'function' && isTestEnvironment();
             const novaAction = () => {
                 targets.slice().forEach(monster => {
                     const attackValue = (rollDice(skill.damageDice) * level + getStat(gameState.player, 'magicPower')) * getSkillPowerMult(gameState.player);
@@ -8988,7 +8986,7 @@ function processTurn() {
                 return;
             }
 
-            const isTest = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+            const isTest = typeof isTestEnvironment === 'function' && isTestEnvironment();
             if (isTest && typeof prompt === 'function') {
                 const msg = choices.map((c, i) => `${i}: ${c.label}`).join('\n');
                 const res = prompt(msg);
@@ -9377,8 +9375,7 @@ upgradeMercenarySkill, upgradeMonsterSkill, useItem, useItemOnTarget, useSkill, 
 };
 // ======================= 추가 시작 =======================
 // 1초마다 모든 유닛의 효과 아이콘 인덱스를 업데이트하고, 다시 렌더링합니다.
-if (!(typeof navigator !== 'undefined' && navigator.userAgent &&
-    (navigator.userAgent.includes('Node.js') || navigator.userAgent.includes('jsdom')))) {
+if (!(typeof isTestEnvironment === 'function' && isTestEnvironment())) {
     setInterval(() => {
         if (!gameState.gameRunning) return; // 게임이 멈췄을 땐 실행하지 않음
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -10,6 +10,7 @@ async function loadGame(options = {}) {
   let html = fs.readFileSync(htmlPath, 'utf8');
   html = html.replace(/<link rel="stylesheet" href="style.css">/, '');
   html = html.replace('<script src="dice.js"></script>', '');
+  html = html.replace('<script src="src/env.js"></script>', '');
   const dom = new JSDOM(html, {
     runScripts: 'dangerously',
     resources: 'usable',
@@ -37,7 +38,7 @@ async function loadGame(options = {}) {
   });
 
   const ctx = dom.getInternalVMContext();
-  const modules = ['src/state.js', 'src/ui.js', 'src/mechanics.js'];
+  const modules = ['src/env.js', 'src/state.js', 'src/ui.js', 'src/mechanics.js'];
   for (const file of modules) {
     const code = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
     const script = new vm.Script(code, { filename: file });


### PR DESCRIPTION
## Summary
- add `isTestEnvironment` helper
- load helper into DOM tests and the page
- replace ad hoc environment checks in mechanics

## Testing
- `npm test` *(fails: monster aura icon missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d0cc3d8a0832798cf3ca3964f861d