### PR TITLE
Remove background color on combat messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,7 +588,6 @@
             border-left-color: #2196F3;
         }
         .message.combat {
-            background-color: #ba5f5f
             border-left-color: #f44336;
         }
         .message.treasure {


### PR DESCRIPTION
## Summary
- drop background color from `.message.combat` styling

## Testing
- `npm test` *(fails: `buffs.test.js failed with code 1`)*

------
https://chatgpt.com/codex/tasks/task_e_684d0e99b8b08327bab4766a43f3c69c