### PR TITLE
Add supporters to game state

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -60,6 +60,7 @@
         },
         activeMercenaries: [],
         standbyMercenaries: [],
+        supporters: [null, null],
         get mercenaries(){ return this.activeMercenaries; },
         monsters: [],
         corpses: [],


### PR DESCRIPTION
## Summary
- extend `gameState` with a `supporters` array so two supporter mercenaries can be stored

## Testing
- `npm test` *(fails: `manaOnKillAffix.test.js` due to "mana on kill not applied" and `damageReflect.test.js` due to "reflected damage incorrect")*

------
https://chatgpt.com/codex/tasks/task_e_684d1c71e2008327a647dddabed1c65c