### PR TITLE
Remove obsolete effect icon cycling

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4760,41 +4760,6 @@ function killMonster(monster, killer = null) {
             return died;
         }
 
-        // [새로 추가된 함수] 1초마다 아이콘만 가볍게 새로고침합니다.
-        function updateAllEffectIcons() {
-            const allUnits = [gameState.player, ...gameState.activeMercenaries.filter(m=>m.alive), ...gameState.monsters];
-            for (const unit of allUnits) {
-                if (!unit || unit.x < 0 || unit.y < 0) continue; // 맵에 없는 유닛은 건너뜁니다.
-
-                const cellDiv = gameState.cellElements[unit.y]?.[unit.x];
-                if (!cellDiv) continue;
-
-                const state = effectCycleState[unit.id];
-                if (state) {
-                    const buffContainer = cellDiv.buffContainer;
-                    const statusContainer = cellDiv.statusContainer;
-
-                    // 버프 아이콘 업데이트
-                    if (buffContainer) {
-                        buffContainer.innerHTML = '';
-                        if (state.buffs && state.buffs.length > 0) {
-                            const currentBuffIcon = state.buffs[state.buffIndex];
-                            buffContainer.innerHTML = `<span class="effect-icon">${currentBuffIcon}</span>`;
-                        }
-                    }
-
-                    // 디버프 아이콘 업데이트
-                    if (statusContainer) {
-                        statusContainer.innerHTML = '';
-                        if (state.debuffs && state.debuffs.length > 0) {
-                            const currentDebuffIcon = state.debuffs[state.debuffIndex];
-                            statusContainer.innerHTML = `<span class="effect-icon">${currentDebuffIcon}</span>`;
-                        }
-                    }
-                }
-            }
-        }
-
         // 던전 렌더링
         function renderDungeon() {
             const dungeonEl = document.getElementById('dungeon');

--- a/src/state.js
+++ b/src/state.js
@@ -4,9 +4,6 @@
     const CELL_SIZE = 33;     // 셀 크기(갭 포함)
     const CELL_WIDTH = CELL_SIZE - 1; // 실제 셀 너비
 
-    // 효과 사이클 관리를 위한 상태
-    const effectCycleState = {};
-
     let gameState = {
         turn: 0,
         gameRunning: true,
@@ -94,11 +91,10 @@
     global.FOG_RADIUS = FOG_RADIUS;
     global.CELL_SIZE = CELL_SIZE;
     global.CELL_WIDTH = CELL_WIDTH;
-    global.effectCycleState = effectCycleState;
     if (typeof document !== 'undefined') {
         document.documentElement.style.setProperty('--cell-width', `${CELL_WIDTH}px`);
     }
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH, effectCycleState };
+        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH };
     }
 })(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- delete unused `effectCycleState` global and exports
- remove `updateAllEffectIcons` helper

## Testing
- `npm test` *(fails: reflected damage incorrect)*

------
https://chatgpt.com/codex/tasks/task_e_684d3cc265108327b05e4340898d7788