### PR TITLE
Keep monster corpses indefinitely

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -575,7 +575,8 @@ const MERCENARY_NAMES = [
 
         const MAX_FULLNESS = 100;
         const FULLNESS_LOSS_PER_TURN = 0.01;
-        const CORPSE_TURNS = 60; // how long a corpse remains on the map
+        // corpses now remain indefinitely so they never disappear on their own
+        const CORPSE_TURNS = Infinity;
         const CORRIDOR_WIDTH = 7; // width of dungeon corridors
 
         function carveWideCorridor(map, x1, y1, x2, y2) {

--- a/tests/corpseDecay.test.js
+++ b/tests/corpseDecay.test.js
@@ -31,17 +31,17 @@ async function run() {
     process.exit(1);
   }
 
-  const turns = monster.turnsLeft;
-  for (let i = 0; i < turns; i++) {
+  // corpses should remain even after many turns
+  for (let i = 0; i < 100; i++) {
     processTurn();
   }
 
-  if (gameState.corpses.includes(monster)) {
-    console.error('corpse not removed after duration');
+  if (!gameState.corpses.includes(monster)) {
+    console.error('corpse disappeared unexpectedly');
     process.exit(1);
   }
-  if (gameState.dungeon[1][1] !== 'empty') {
-    console.error('dungeon tile not cleared after corpse decay');
+  if (gameState.dungeon[1][1] !== 'corpse') {
+    console.error('dungeon tile no longer marked corpse');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- stop corpses from decaying by setting `CORPSE_TURNS` to `Infinity`
- update corpse decay test to expect corpses to remain after multiple turns

## Testing
- `npm test` *(fails: `nova.test.js` and others)*

------
https://chatgpt.com/codex/tasks/task_e_684d3e28957083279fb65db79e48e53d