### PR TITLE
Optimize monster AI vision check

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7341,7 +7341,19 @@ function processTurn() {
                         }
                     }
                 }
-                
+
+                const distToPlayer = getDistance(monster.x, monster.y, gameState.player.x, gameState.player.y);
+                const nearestMercDist = Math.min(
+                    ...gameState.activeMercenaries
+                        .filter(m => m.alive)
+                        .map(m => getDistance(monster.x, monster.y, m.x, m.y)),
+                    Infinity
+                );
+                if (distToPlayer > MONSTER_VISION && nearestMercDist > MONSTER_VISION) {
+                    monster.hasActed = true;
+                    continue;
+                }
+
                 let nearestTarget = null;
                 let nearestDistance = Infinity;
                 


### PR DESCRIPTION
## Summary
- improve monster vision logic in `processTurn`
- skip monster actions if player and mercenaries are beyond MONSTER_VISION

## Testing
- `npm install`
- `node runTests.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_684d46fb31d88327b40954d7dcaa06de