### PR TITLE
Remove on-map buff icons

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3895,69 +3895,14 @@ function updateMaterialsDisplay() {
          * @param {HTMLElement} cellDiv - 해당 유닛이 위치한 셀의 div 요소
          */
         function updateUnitEffectIcons(unit, cellDiv) {
-            let buffContainer = cellDiv.buffContainer || cellDiv.querySelector('.buff-container');
-            let statusContainer = cellDiv.statusContainer || cellDiv.querySelector('.status-container');
-
-            if (!buffContainer) {
-                buffContainer = document.createElement('div');
-                buffContainer.className = 'buff-container';
-                cellDiv.appendChild(buffContainer);
-                cellDiv.buffContainer = buffContainer;
+            if (cellDiv.buffContainer) {
+                cellDiv.buffContainer.remove();
+                cellDiv.buffContainer = null;
             }
-            if (!statusContainer) {
-                statusContainer = document.createElement('div');
-                statusContainer.className = 'status-container';
-                cellDiv.appendChild(statusContainer);
-                cellDiv.statusContainer = statusContainer;
+            if (cellDiv.statusContainer) {
+                cellDiv.statusContainer.remove();
+                cellDiv.statusContainer = null;
             }
-
-            if (!buffContainer || !statusContainer) return;
-
-            buffContainer.innerHTML = '';
-            statusContainer.innerHTML = '';
-
-            if (!unit || !unit.id) return;
-
-            const allBuffIcons = new Set();
-            getActiveAuraIcons(unit).forEach(icon => allBuffIcons.add(icon));
-            if (Array.isArray(unit.buffs)) {
-                unit.buffs.forEach(buff => {
-                    const skillDef = Object.values(SKILL_DEFS).find(def => def.name === buff.name);
-                    if (skillDef && skillDef.icon === '⬆️') {
-                        allBuffIcons.add(skillDef.icon);
-                    }
-                });
-            }
-
-            const allDebuffIcons = new Set();
-            const STATUS_KEYS = ['poison', 'burn', 'freeze', 'bleed', 'paralysis', 'nightmare', 'silence', 'petrify', 'debuff'];
-            STATUS_KEYS.forEach(status => {
-                if (unit[status] && unit[status + 'Turns'] > 0) {
-                    allDebuffIcons.add(STATUS_ICONS[status]);
-                }
-            });
-            if (Array.isArray(unit.buffs)) {
-                unit.buffs.forEach(buff => {
-                    const skillDef = Object.values(SKILL_DEFS).find(def => def.name === buff.name);
-                    if (skillDef && skillDef.icon === '⬇️') {
-                        allDebuffIcons.add(skillDef.icon);
-                    }
-                });
-            }
-
-            allBuffIcons.forEach(icon => {
-                const iconSpan = document.createElement('span');
-                iconSpan.className = 'effect-icon';
-                iconSpan.textContent = icon;
-                buffContainer.appendChild(iconSpan);
-            });
-
-            allDebuffIcons.forEach(icon => {
-                const iconSpan = document.createElement('span');
-                iconSpan.className = 'effect-icon';
-                iconSpan.textContent = icon;
-                statusContainer.appendChild(iconSpan);
-            });
         }
 
         // 몬스터 생성
@@ -5032,17 +4977,7 @@ function killMonster(monster, killer = null) {
                         cellDiv.tileBg = tileBg;
                         cellDiv.className = 'cell';
 
-                        // 버프/디버프 아이콘 컨테이너
-                        const buffContainer = document.createElement('div');
-                        buffContainer.className = 'buff-container';
-                        cellDiv.appendChild(buffContainer);
-                        cellDiv.buffContainer = buffContainer;
-
-                        // 상태이상 아이콘 컨테이너
-                        const statusContainer = document.createElement('div');
-                        statusContainer.className = 'status-container';
-                        cellDiv.appendChild(statusContainer);
-                        cellDiv.statusContainer = statusContainer;
+                        // previous buff/debuff containers removed
 
                         dungeonEl.appendChild(cellDiv);
                         cellRow.push(cellDiv);
@@ -5420,15 +5355,7 @@ function killMonster(monster, killer = null) {
                     cellDiv.tileBg = tileBg;
                     cellDiv.className = 'cell';
 
-                    const buffContainer = document.createElement('div');
-                    buffContainer.className = 'buff-container';
-                    cellDiv.appendChild(buffContainer);
-                    cellDiv.buffContainer = buffContainer;
-
-                    const statusContainer = document.createElement('div');
-                    statusContainer.className = 'status-container';
-                    cellDiv.appendChild(statusContainer);
-                    cellDiv.statusContainer = statusContainer;
+                    // previous buff/debuff containers removed
 
                     dungeonEl.appendChild(cellDiv);
                     cellRow.push(cellDiv);

--- a/tests/effectIconsDisplay.test.js
+++ b/tests/effectIconsDisplay.test.js
@@ -31,17 +31,12 @@ async function run() {
   const buffContainer = div.querySelector('.buff-container');
   const debuffContainer = div.querySelector('.status-container');
 
-  if (!buffContainer || !debuffContainer) {
-    console.error('setup failed');
+  if (buffContainer || debuffContainer) {
+    console.error('effect icons should not be displayed');
     process.exit(1);
   }
 
-  if (buffContainer.children.length < 2 || debuffContainer.children.length < 2) {
-    console.error('icons not displayed correctly');
-    process.exit(1);
-  }
-
-  console.log('icon display ok');
+  console.log('icons removed ok');
 }
 
 run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/effectIconsLayout.test.js
+++ b/tests/effectIconsLayout.test.js
@@ -31,30 +31,12 @@ async function run() {
   const buff = div.querySelector('.buff-container');
   const status = div.querySelector('.status-container');
 
-  if (!buff || !status) {
-    console.error('containers not created');
+  if (buff || status) {
+    console.error('effect containers should not exist');
     process.exit(1);
   }
 
-  if (buff.children.length !== 5 || status.children.length !== 4) {
-    console.error('incorrect number of icons');
-    process.exit(1);
-  }
-
-  const buffStyle = win.getComputedStyle(buff);
-  const statusStyle = win.getComputedStyle(status);
-
-  if (buffStyle.display !== 'flex' || statusStyle.display !== 'flex') {
-    console.error('display style incorrect');
-    process.exit(1);
-  }
-
-  if (buffStyle.flexWrap !== 'wrap' || statusStyle.flexWrap !== 'wrap') {
-    console.error('flex-wrap missing');
-    process.exit(1);
-  }
-
-  console.log('icon layout ok');
+  console.log('no icon layout ok');
 }
 
 run().catch(e => { console.error(e); process.exit(1); });

--- a/tests/monsterAuraDisplay.test.js
+++ b/tests/monsterAuraDisplay.test.js
@@ -34,8 +34,8 @@ async function run() {
 
   const buffContainer = cellDiv.querySelector('.buff-container');
   const icon = SKILL_DEFS[monster.auraSkill].icon;
-  if (!buffContainer || !buffContainer.textContent.includes(icon)) {
-    console.error('monster aura icon missing');
+  if (buffContainer) {
+    console.error('monster aura icon should not display');
     process.exit(1);
   }
 }

--- a/tests/playerAuraDisplay.test.js
+++ b/tests/playerAuraDisplay.test.js
@@ -32,8 +32,8 @@ async function run() {
 
   const buffContainer = cellDiv.querySelector('.buff-container');
   const icon = SKILL_DEFS['MightAura'].icon;
-  if (!buffContainer || !buffContainer.textContent.includes(icon)) {
-    console.error('player aura icon missing on tile');
+  if (buffContainer) {
+    console.error('aura icon should not display on tile');
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- remove DOM elements and logic that placed buff/debuff icons above units
- adjust related tests to expect no per-unit icons

## Testing
- `npm test` *(fails: healOnKillAffix.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684d461aaa9c8327aacaa4a878e3ea42