### PR TITLE
Introduce dirty cell tracking for dungeon rendering

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -11,6 +11,7 @@
         dungeonSize: 80,
         fogOfWar: [],
         cellElements: [],
+        dirtyCells: new Set(),
         player: {
             id: 'player',
             x: 1,


### PR DESCRIPTION
## Summary
- add `dirtyCells` to game state
- create `markDirty` and `setDungeonCell` helpers
- update fog of war and camera movement to mark tiles dirty
- restrict `renderDungeon` to only update dirty cells

## Testing
- `npm test` *(fails: mana.test.js - mana did not regenerate on turn)*

------
https://chatgpt.com/codex/tasks/task_e_684d5c8208148327be35cd29c2d8e778