### PR TITLE
Fix mercenary reposition dirty tiles

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7286,8 +7286,14 @@ function processTurn() {
             sortedMercenaries.forEach(mercenary => {
                 const key = `${mercenary.nextX},${mercenary.nextY}`;
                 if (!occupied.has(key)) {
+                    const oldX = mercenary.x;
+                    const oldY = mercenary.y;
                     mercenary.x = mercenary.nextX;
                     mercenary.y = mercenary.nextY;
+                    if (oldX !== mercenary.x || oldY !== mercenary.y) {
+                        markDirty(oldX, oldY);
+                        markDirty(mercenary.nextX, mercenary.nextY);
+                    }
                     occupied.add(key);
                 }
             });


### PR DESCRIPTION
## Summary
- track mercenary's previous position when resolving overlaps
- mark both old and new tiles dirty after a mercenary moves

## Testing
- `node runTests.js` *(fails: elementDamagePrefix.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d66acd0848327a88de8da8674e90e