### PR TITLE
Clarify gameState origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Install dependencies with:
 npm install
 ```
 
+The core `gameState` object used throughout the game is created in
+[`src/state.js`](src/state.js). It exposes properties like `dirtyCells`
+on the global object so other modules such as `src/mechanics.js` can
+access them directly.
+
 ## Testing
 
 The test suite relies on development dependencies such as **jsdom**. Ensure they

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -562,6 +562,8 @@ const MERCENARY_NAMES = [
 // ==========================
 // Dungeon dirty cell helpers
 // ==========================
+// `gameState` is defined in src/state.js and attached globally. It
+// includes the `dirtyCells` Set used here for efficient re-rendering.
 function markDirty(x, y) {
     if (!gameState.dirtyCells) return;
     gameState.dirtyCells.add(`${x},${y}`);


### PR DESCRIPTION
## Summary
- update README to mention that `gameState` comes from `src/state.js`
- document dirtyCells origin in `src/mechanics.js`

## Testing
- `npm test` *(fails: damageReflect.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684d6b5fb8b4832789ac4fe3d0195973