### PR TITLE
Remove unused dirty cell logic and optimize fog rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,8 @@ npm install
 ```
 
 The core `gameState` object used throughout the game is created in
-[`src/state.js`](src/state.js). It exposes properties like `dirtyCells`
-on the global object so other modules such as `src/mechanics.js` can
-access them directly.
+[`src/state.js`](src/state.js) and is attached to the global object so
+other modules such as `src/mechanics.js` can access it directly.
 
 ## Testing
 

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3833,13 +3833,16 @@ function updateMaterialsDisplay() {
 
         // 안개 업데이트
         function updateFogOfWar() {
-            for (let y = 0; y < gameState.dungeonSize; y++) {
+            const startY = Math.max(0, gameState.player.y - FOG_RADIUS);
+            const endY = Math.min(gameState.dungeonSize - 1, gameState.player.y + FOG_RADIUS);
+            const startX = Math.max(0, gameState.player.x - FOG_RADIUS);
+            const endX = Math.min(gameState.dungeonSize - 1, gameState.player.x + FOG_RADIUS);
+
+            for (let y = startY; y <= endY; y++) {
                 if (!gameState.fogOfWar[y]) gameState.fogOfWar[y] = [];
-                for (let x = 0; x < gameState.dungeonSize; x++) {
+                for (let x = startX; x <= endX; x++) {
                     if (getDistance(x, y, gameState.player.x, gameState.player.y) <= FOG_RADIUS) {
                         gameState.fogOfWar[y][x] = false;
-                    } else if (gameState.fogOfWar[y][x] === undefined) {
-                        gameState.fogOfWar[y][x] = true;
                     }
                 }
             }

--- a/src/state.js
+++ b/src/state.js
@@ -11,7 +11,6 @@
         dungeonSize: 80,
         fogOfWar: [],
         cellElements: [],
-        dirtyCells: new Set(),
         player: {
             id: 'player',
             x: 1,
@@ -88,16 +87,6 @@
         currentMapModifiers: {}
     };
 
-    /**
-     * \uC9C0\uC815\uB41C \uC88C\uD45C\uC758 \uC140\uC744 \uB2E4\uC74C \uB80C\uB354\uB9C1 \uB300\uC0C1\uC73C\uB85C \uD45C\uC2DC\uD569\uB2C8\uB2E4.
-     * @param {number} x
-     * @param {number} y
-     */
-    function markDirty(x, y) {
-        if (x >= 0 && x < gameState.dungeonSize && y >= 0 && y < gameState.dungeonSize) {
-            gameState.dirtyCells.add(`${x},${y}`); // Set\uC5D0 "x,y" \uD615\uD0DC\uC758 \uBB38\uC790\uC5F4\uB85C \uC800\uC7A5
-        }
-    }
     global.gameState = gameState;
     global.MONSTER_VISION = MONSTER_VISION;
     global.FOG_RADIUS = FOG_RADIUS;
@@ -107,6 +96,6 @@
         document.documentElement.style.setProperty('--cell-width', `${CELL_WIDTH}px`);
     }
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = { gameState, markDirty, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH };
+        module.exports = { gameState, MONSTER_VISION, FOG_RADIUS, CELL_SIZE, CELL_WIDTH };
     }
 })(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- clean up references to `dirtyCells` and remove `markDirty`
- update README to describe global `gameState`
- optimize fog of war updates to only check tiles near the player

## Testing
- `npm test` *(fails: mana.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684d784de4f88327b4db984b9efb921c