### PR TITLE
Add darkness fog-of-war and conditional monster updates

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,6 +39,12 @@
   /* border: 1px solid #000; */
 }
 
+.cell.darkness {
+  background: #000;
+  color: transparent;
+  background-image: none !important;
+}
+
 .cell.empty.player {
   background-image: url("assets/images/player.png"), url("assets/images/floor-tile.png");
   background-size: contain, cover;


### PR DESCRIPTION
## Summary
- hide unseen map tiles with new `darkness` styling
- skip rendering details for fogged cells
- skip offscreen monster logic unless visible

## Testing
- `npm test` *(fails: `damageReflect.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684d79d448c083278716d8710b1d0fe8