### PR TITLE
Switch to canvas-based rendering overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,13 @@
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.8);
             border: 2px solid #444;
         }
+        #game-canvas {
+            position: absolute;
+            top: 0;
+            left: 0;
+            image-rendering: pixelated;
+            z-index: 0;
+        }
         :root {
             --cell-width: 32px;
             --panel-bg: #f5f5dc;
@@ -869,6 +876,7 @@
     <div class="main-container">
         <div class="game-area">
             <div class="dungeon-container">
+                <canvas id="game-canvas"></canvas>
                 <div class="dungeon" id="dungeon"></div>
             </div>
             <div class="message-log" id="message-log"></div>
@@ -1029,6 +1037,7 @@
     </div>
     <audio id="bgm-player"></audio>
     <script src="dice.js"></script>
+    <script type="module" src="src/canvasRenderer.js"></script>
     <script type="module" src="src/state.js"></script>
     <script type="module" src="src/ui.js"></script>
     <script type="module" src="src/mechanics.js"></script>

--- a/src/canvasRenderer.js
+++ b/src/canvasRenderer.js
@@ -1,0 +1,49 @@
+((global)=>{
+  if (typeof document === 'undefined') {
+    global.CanvasRenderer = {
+      render(){},
+      initialize(){},
+    };
+    return;
+  }
+  const canvas = document.getElementById('game-canvas');
+  let ctx = null;
+  if (canvas && canvas.getContext) {
+    const isJsdom = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+    if (!isJsdom) {
+      try {
+        ctx = canvas.getContext('2d');
+      } catch (e) {
+        ctx = null;
+      }
+    }
+  }
+  function initialize(size){
+    if (!canvas || !ctx) return;
+    canvas.width = size * CELL_WIDTH;
+    canvas.height = size * CELL_WIDTH;
+  }
+  function drawDungeon(dungeon){
+    if (!ctx) return;
+    for(let y=0;y<dungeon.length;y++){
+      for(let x=0;x<dungeon[y].length;x++){
+        const cell = dungeon[y][x];
+        if (cell === 'wall') ctx.fillStyle = '#222';
+        else ctx.fillStyle = '#444';
+        ctx.fillRect(x*CELL_WIDTH, y*CELL_WIDTH, CELL_WIDTH, CELL_WIDTH);
+      }
+    }
+  }
+  function drawPlayer(player){
+    if (!ctx) return;
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(player.x*CELL_WIDTH, player.y*CELL_WIDTH, CELL_WIDTH, CELL_WIDTH);
+  }
+  function render(state){
+    if (!ctx) return;
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    drawDungeon(state.dungeon);
+    drawPlayer(state.player);
+  }
+  global.CanvasRenderer = { initialize, render };
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -4763,6 +4763,9 @@ function killMonster(monster, killer = null) {
                 }
             }
         }
+        if (typeof CanvasRenderer !== 'undefined' && CanvasRenderer.render) {
+            CanvasRenderer.render(gameState);
+        }
 
         function handleDungeonClick(e) {
             initializeAudio();
@@ -5285,6 +5288,9 @@ function killMonster(monster, killer = null) {
             updateInventoryDisplay();
             updateSkillDisplay();
             updateMercenaryDisplay();
+            if (typeof CanvasRenderer !== 'undefined' && CanvasRenderer.initialize) {
+                CanvasRenderer.initialize(gameState.dungeonSize);
+            }
             renderDungeon();
             updateCamera();
         }
@@ -6358,6 +6364,9 @@ function killMonster(monster, killer = null) {
 
             updateStats();
             updateMercenaryDisplay();
+            if (typeof CanvasRenderer !== 'undefined' && CanvasRenderer.initialize) {
+                CanvasRenderer.initialize(gameState.dungeonSize);
+            }
             renderDungeon();
         }
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -37,7 +37,7 @@ async function loadGame(options = {}) {
   });
 
   const ctx = dom.getInternalVMContext();
-  const modules = ['src/state.js', 'src/ui.js', 'src/mechanics.js'];
+  const modules = ['src/state.js', 'src/ui.js', 'src/canvasRenderer.js', 'src/mechanics.js'];
   for (const file of modules) {
     const code = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
     const script = new vm.Script(code, { filename: file });


### PR DESCRIPTION
## Summary
- add `canvasRenderer.js` for drawing dungeon and player
- insert `<canvas id="game-canvas">` in `index.html`
- initialize and render canvas in mechanics
- ensure tests load the canvas module

## Testing
- `npm test` *(fails: corpseDecay.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d5c3abc83278f9559fe84e5c968