### PR TITLE
Disable fog of war and tile effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         .dungeon {
             position: absolute;
             display: grid;
-            --dungeon-size: 80;
+            --dungeon-size: 40;
             grid-template-columns: repeat(var(--dungeon-size), var(--cell-width));
             grid-template-rows: repeat(var(--dungeon-size), var(--cell-width));
             gap: 1px;
@@ -93,13 +93,9 @@
         .player {
             background: radial-gradient(circle, #4CAF50, #45a049);
             color: white;
-            box-shadow: 0 0 8px rgba(76, 175, 80, 0.6);
-            animation: playerGlow 2s ease-in-out infinite alternate;
+            box-shadow: none;
+            animation: none;
             z-index: 10;
-        }
-        @keyframes playerGlow {
-            from { box-shadow: 0 0 8px rgba(76, 175, 80, 0.6); }
-            to { box-shadow: 0 0 12px rgba(76, 175, 80, 0.9); }
         }
         .mercenary {
             background: radial-gradient(circle, #2196F3, #1976D2);
@@ -110,24 +106,20 @@
         .monster {
             background: radial-gradient(circle, #f44336, #d32f2f);
             color: white;
-            box-shadow: 0 0 6px rgba(244, 67, 54, 0.5);
-            animation: monsterPulse 1.5s ease-in-out infinite alternate;
+            box-shadow: none;
+            animation: none;
         }
         .champion {
             background: radial-gradient(circle, #ff9800, #f57c00);
             color: white;
-            box-shadow: 0 0 8px rgba(255, 152, 0, 0.7);
-            animation: monsterPulse 1.5s ease-in-out infinite alternate;
+            box-shadow: none;
+            animation: none;
         }
         .elite {
             background: radial-gradient(circle, #9C27B0, #7B1FA2);
             color: white;
-            box-shadow: 0 0 8px rgba(156, 39, 176, 0.7);
-            animation: monsterPulse 1.5s ease-in-out infinite alternate;
-        }
-        @keyframes monsterPulse {
-            from { transform: scale(1); }
-            to { transform: scale(1.1); }
+            box-shadow: none;
+            animation: none;
         }
         .treasure {
             background: none;
@@ -136,13 +128,9 @@
             background-position: center, center;
             background-repeat: no-repeat, no-repeat;
             color: transparent;
-            box-shadow: 0 0 10px rgba(255, 215, 0, 0.7);
-            animation: treasureSparkle 1s ease-in-out infinite alternate;
+            box-shadow: none;
+            animation: none;
             font-size: 20px;
-        }
-        @keyframes treasureSparkle {
-            from { box-shadow: 0 0 10px rgba(255, 215, 0, 0.7); }
-            to { box-shadow: 0 0 15px rgba(255, 215, 0, 1); }
         }
         .item {
             background: none;
@@ -247,8 +235,8 @@
             background-size: cover;
             background-position: center;
             color: white;
-            box-shadow: 0 0 15px rgba(0, 188, 212, 0.8);
-            animation: exitPortal 2s ease-in-out infinite;
+            box-shadow: none;
+            animation: none;
             font-size: 20px;
             border: 2px solid #B2EBF2;
         }
@@ -260,20 +248,6 @@
             color: #333;
             font-weight: bold;
             font-size: 20px;
-        }
-        @keyframes exitPortal {
-            0% { 
-                box-shadow: 0 0 15px rgba(0, 188, 212, 0.8);
-                transform: scale(1);
-            }
-            50% { 
-                box-shadow: 0 0 25px rgba(0, 188, 212, 1);
-                transform: scale(1.05);
-            }
-            100% { 
-                box-shadow: 0 0 15px rgba(0, 188, 212, 0.8);
-                transform: scale(1);
-            }
         }
         .empty {
             background-color: #3a3a3a;

--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -3713,11 +3713,7 @@ function updateMaterialsDisplay() {
             for (let y = 0; y < gameState.dungeonSize; y++) {
                 if (!gameState.fogOfWar[y]) gameState.fogOfWar[y] = [];
                 for (let x = 0; x < gameState.dungeonSize; x++) {
-                    if (getDistance(x, y, gameState.player.x, gameState.player.y) <= FOG_RADIUS) {
-                        gameState.fogOfWar[y][x] = false;
-                    } else if (gameState.fogOfWar[y][x] === undefined) {
-                        gameState.fogOfWar[y][x] = true;
-                    }
+                    gameState.fogOfWar[y][x] = false;
                 }
             }
         }
@@ -3762,100 +3758,10 @@ function updateMaterialsDisplay() {
          * @param {HTMLElement} cellDiv - 해당 유닛이 위치한 셀의 div 요소
          */
         function updateUnitEffectIcons(unit, cellDiv) {
-            let buffContainer = cellDiv.querySelector('.buff-container');
-            let statusContainer = cellDiv.querySelector('.status-container');
-
-            if (!buffContainer) {
-                buffContainer = document.createElement('div');
-                buffContainer.className = 'buff-container';
-                cellDiv.appendChild(buffContainer);
-            }
-            if (!statusContainer) {
-                statusContainer = document.createElement('div');
-                statusContainer.className = 'status-container';
-                cellDiv.appendChild(statusContainer);
-            }
-
-            buffContainer.innerHTML = '';
-            statusContainer.innerHTML = '';
-
-            if (!unit || !unit.id) return;
-
-            // 1. Collect buff and debuff icons separately
-            const allBuffIcons = [];
-            const allDebuffIcons = [];
-
-            // Auras are buffs
-            allBuffIcons.push(...getActiveAuraIcons(unit));
-
-            // Status ailments are debuffs
-            const STATUS_KEYS = ['poison', 'burn', 'freeze', 'bleed', 'paralysis', 'nightmare', 'silence', 'petrify', 'debuff'];
-            STATUS_KEYS.forEach(status => {
-                if (unit[status] && unit[status + 'Turns'] > 0) {
-                    allDebuffIcons.push(STATUS_ICONS[status]);
-                }
-            });
-
-            // Buffs array uses ⬆️ for buffs and ⬇️ for debuffs
-            if (Array.isArray(unit.buffs)) {
-                unit.buffs.forEach(buff => {
-                    const skillDef = Object.values(SKILL_DEFS).find(def => def.name === buff.name);
-                    if (skillDef && skillDef.icon) {
-                        if (skillDef.icon === '⬆️') {
-                            allBuffIcons.push(skillDef.icon);
-                        } else if (skillDef.icon === '⬇️') {
-                            allDebuffIcons.push(skillDef.icon);
-                        }
-                    }
-                });
-            }
-
-            const uniqueBuffs = [...new Set(allBuffIcons)];
-            const uniqueDebuffs = [...new Set(allDebuffIcons)];
-
-            // 2. Update effectCycleState
-            if (uniqueBuffs.length === 0 && uniqueDebuffs.length === 0) {
-                delete effectCycleState[unit.id];
-            } else {
-                const currentState = effectCycleState[unit.id] || {};
-
-                const buffsChanged = !currentState.buffs || JSON.stringify(currentState.buffs) !== JSON.stringify(uniqueBuffs);
-                const debuffsChanged = !currentState.debuffs || JSON.stringify(currentState.debuffs) !== JSON.stringify(uniqueDebuffs);
-
-                if (!effectCycleState[unit.id]) {
-                    effectCycleState[unit.id] = { buffs: [], debuffs: [], buffIndex: 0, debuffIndex: 0 };
-                }
-
-                if (buffsChanged) {
-                    effectCycleState[unit.id].buffs = uniqueBuffs;
-                    effectCycleState[unit.id].buffIndex = 0;
-                }
-                if (debuffsChanged) {
-                    effectCycleState[unit.id].debuffs = uniqueDebuffs;
-                    effectCycleState[unit.id].debuffIndex = 0;
-                }
-            }
-
-            // 3. Render current icons
-            const state = effectCycleState[unit.id];
-            if (state) {
-                // Buff icon (top)
-                if (state.buffs && state.buffs.length > 0) {
-                    const currentBuffIcon = state.buffs[state.buffIndex];
-                    const iconSpan = document.createElement('span');
-                    iconSpan.className = 'effect-icon';
-                    iconSpan.textContent = currentBuffIcon;
-                    buffContainer.appendChild(iconSpan);
-                }
-                // Debuff icon (bottom)
-                if (state.debuffs && state.debuffs.length > 0) {
-                    const currentDebuffIcon = state.debuffs[state.debuffIndex];
-                    const iconSpan = document.createElement('span');
-                    iconSpan.className = 'effect-icon';
-                    iconSpan.textContent = currentDebuffIcon;
-                    statusContainer.appendChild(iconSpan);
-                }
-            }
+            const buffContainer = cellDiv.querySelector('.buff-container');
+            const statusContainer = cellDiv.querySelector('.status-container');
+            if (buffContainer) buffContainer.innerHTML = '';
+            if (statusContainer) statusContainer.innerHTML = '';
         }
 
         // 몬스터 생성

--- a/src/state.js
+++ b/src/state.js
@@ -8,7 +8,7 @@
         turn: 0,
         gameRunning: true,
         dungeon: [],
-        dungeonSize: 80,
+        dungeonSize: 40,
         fogOfWar: [],
         cellElements: [],
         player: {

--- a/style.css
+++ b/style.css
@@ -201,21 +201,21 @@
 
 /* ---- Special unit glow effects ---- */
 .cell.elite {
-  box-shadow: 0 0 8px rgba(244, 67, 54, 0.7);
-  animation: monsterPulse 1.5s ease-in-out infinite alternate;
+  box-shadow: none;
+  animation: none;
 }
 
 .cell.champion {
   /* BUG FIX: 챔피언 셀의 배경색을 명시적으로 투명하게 설정하여 
      하위 바닥 타일 이미지가 보이도록 수정합니다. */
   background-color: transparent;
-  box-shadow: 0 0 8px rgba(255, 235, 59, 0.7);
-  animation: monsterPulse 1.5s ease-in-out infinite alternate;
+  box-shadow: none;
+  animation: none;
 }
 
 .cell.superior {
-  box-shadow: 0 0 8px rgba(33, 150, 243, 0.7);
-  animation: monsterPulse 1.5s ease-in-out infinite alternate;
+  box-shadow: none;
+  animation: none;
 }
 
 .inv-filter-btn {
@@ -299,7 +299,7 @@
 .low-health {
   /* 이미지 자체가 붉은 색으로 보이도록 필터를 적용합니다. */
   filter: brightness(0.6) sepia(1) hue-rotate(-50deg) saturate(6);
-  animation: monsterPulse 1s ease-in-out infinite alternate;
+  animation: none;
 }
 
 /* 시체 셀 스타일 및 아이콘 표시 */
@@ -468,19 +468,9 @@
     background-repeat: no-repeat;
     z-index: 1000;
     pointer-events: none;
-    animation: simple-nova-expand 0.6s ease-out forwards;
+    animation: none;
 }
 
-@keyframes simple-nova-expand {
-    0% {
-        transform: translate(-50%, -50%) scale(0.2);
-        opacity: 1;
-    }
-    100% {
-        transform: translate(-50%, -50%) scale(1.8);
-        opacity: 0;
-    }
-}
 
 /* ================================================= */
 /* 전투 로그 배경 이미지 버그 수정             */


### PR DESCRIPTION
## Summary
- shrink dungeon size to 40
- reveal entire map by default
- clear buff/debuff emoji display
- remove glow and pulse animations
- default CSS dungeon size updated

## Testing
- `npm test` *(fails: corpseDecay.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684da18672bc832785efab7d18c920e5